### PR TITLE
Add build and deploy configuration for Netlify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Create initial development environment [#4](https://github.com/azavea/fb-gender-survey-dashboard/pull/4)
+- Add Netlify CI build and deployment [#5](https://github.com/azavea/fb-gender-survey-dashboard/pull/5)
+
 ### Added
 
 ### Changed

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[Settings]
+  ID = "gender-survey-dashboard"
+
+[build]
+  base    = "src/app"
+  publish = "build"
+  command = "../../scripts/cibuild"

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -9,7 +9,7 @@ fi
 function usage() {
     echo -n "Usage: $(basename "$0")
 
-Build application for staging or a release.
+Build application for staging or a release in a CI system.
 "
 }
 
@@ -23,15 +23,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        ./scripts/lint
-        ./scripts/test
-
-        # Build static asset bundle
-        docker-compose \
-            run --rm --no-deps \
-            -e NODE_ENV="${NODE_ENV:-production}" \
-            -e INSTALL_ENV="${INSTALL_ENV:-internal}" \
-            -e REACT_APP_GIT_COMMIT="${GIT_COMMIT}" app \
-            yarn build
+        # docker-compose is not available in CI, so build, 
+        # lint and test via the npm commands directly
+        yarn lint
+        yarn test --watchAll=false
+        yarn build
     fi
 fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -17,14 +17,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Lint Bash scripts
-        docker-compose \
-            run --rm --no-deps shellcheck \
-            scripts/*
+        if command -v docker-compose &> /dev/null; then
+            # Lint Bash scripts
+            docker-compose \
+                run --rm --no-deps shellcheck \
+                scripts/*
 
-        # Lint JavaScript
-        docker-compose \
-            run --rm --entrypoint ./node_modules/.bin/eslint \
-            app src/ --ext .js --ext .jsx
+            # Lint JavaScript
+            docker-compose \
+                run --rm --no-deps -e CI app \
+                yarn lint
+        fi
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -17,9 +17,11 @@ if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
     if [[ "${1:-}" = "--help" ]]; then
         usage
     else
-        # Execute React test suite
-        docker-compose \
-            run --rm --no-deps -e CI app \
-            yarn test --watchAll=false
+        if command -v docker-compose &> /dev/null; then
+            # Execute React test suite
+            docker-compose \
+                run --rm --no-deps -e CI app \
+                yarn test --watchAll=false
+        fi
     fi
 fi

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build",
-    "test": "craco test"
+    "test": "craco test",
+    "lint": "eslint ./src --ext .js --ext .jsx"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Overview

Create configuration for building and deploying the application via Netlify. Since Netlify doesn't have docker-compose, adapts `cibuild` to use yarn commands directly.

Connects #2 

## Testing instructions
- Locally, confirm you can still run `./scripts/lint` and `./scripts/test` on your VM.
- Confirm that the build passes and the site is preview-deployed for this application in the Checks section below
https://deploy-preview-5--gender-survey-dashboard.netlify.app/
