### PR TITLE
Ensure docker_users is used instead of ansible_user

### DIFF
--- a/deployment/ansible/roles/fb-gender-survey.docker/tasks/main.yml
+++ b/deployment/ansible/roles/fb-gender-survey.docker/tasks/main.yml
@@ -3,6 +3,7 @@
   pip: name=docker-compose version="{{ docker_compose_version }}"
 
 - name: Add Ansible user to Docker group
-  user: name="{{ ansible_user }}"
-        groups=docker
-        append=yes
+  user: name="{{ item }}"
+    groups=docker
+    append=yes
+  with_items: "{{ docker_users }}"


### PR DESCRIPTION
## Overview

This accounts for alternate Ansible version scenarios where
`ansible_user` is not available. docker_users is always there because
we define it inside of group_vars/all.

## Testing Instructions

 * Run ./scripts/setup` and the environment should provision successfully
