### PR TITLE
Add Breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Breadcrumbs [#25](https://github.com/azavea/fb-gender-survey-dashboard/pull/25)
+
 ### Changed
 
 ### Fixed

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -11,7 +11,7 @@ import Visualizations from './components/Visualizations';
 import theme from './theme';
 
 import { setData } from './redux/app.actions';
-import { GEO_COUNTRY, GEO_REGION } from './utils/constants';
+import { GEO_COUNTRY, GEO_REGION, ROUTES } from './utils/constants';
 
 function App() {
     const dispatch = useDispatch();
@@ -47,13 +47,13 @@ function App() {
                         </Heading>
                     </Flex>
                     <Switch>
-                        <Route exact path='/'>
+                        <Route exact path={ROUTES.HOME}>
                             <GeographySelector />
                         </Route>
-                        <Route path='/questions'>
+                        <Route path={ROUTES.QUESTIONS}>
                             <QuestionSelector />
                         </Route>
-                        <Route path='/visualization'>
+                        <Route path={ROUTES.VISUALIZATIONS}>
                             <Visualizations />
                         </Route>
                     </Switch>

--- a/src/app/src/components/Breadcrumbs.js
+++ b/src/app/src/components/Breadcrumbs.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { IoIosHome } from 'react-icons/io';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    Box,
+    Button,
+} from '@chakra-ui/react';
+
+import { ROUTES } from '../utils/constants';
+
+const CustomBreadcrumb = ({ isCurrentPage, icon, title, to }) => {
+    if (isCurrentPage) {
+        return (
+            <BreadcrumbItem spacing={1} isCurrentPage>
+                <BreadcrumbLink>
+                    <Box bg='rgb(72, 86, 92)' size='sm' p={4}>
+                        {title}
+                    </Box>
+                </BreadcrumbLink>
+            </BreadcrumbItem>
+        );
+    } else {
+        return (
+            <BreadcrumbItem spacing={1}>
+                <BreadcrumbLink as={Link} to={to}>
+                    <Button
+                        bg='rgb(39, 55, 63)'
+                        size='sm'
+                        p={4}
+                        leftIcon={icon}
+                    >
+                        {title}
+                    </Button>
+                </BreadcrumbLink>
+            </BreadcrumbItem>
+        );
+    }
+};
+
+const Breadcrumbs = () => {
+    const { pathname } = useLocation();
+
+    const isQuestions = pathname === ROUTES.QUESTIONS;
+    const isCharts = pathname === ROUTES.VISUALIZATIONS;
+
+    return (
+        <Box bg='rgb(72, 86, 92)' w='100%' p={4} color='white'>
+            <Breadcrumb>
+                <CustomBreadcrumb
+                    to={ROUTES.HOME}
+                    title='Regions & Countries'
+                    icon={<IoIosHome />}
+                />
+                {(isQuestions || isCharts) && (
+                    <CustomBreadcrumb
+                        to={ROUTES.QUESTIONS}
+                        title='Questions'
+                        isCurrentPage={isQuestions}
+                    />
+                )}
+                {isCharts && (
+                    <CustomBreadcrumb
+                        to={ROUTES.VISUALIZATIONS}
+                        title='Charts'
+                        isCurrentPage
+                    />
+                )}
+            </Breadcrumb>
+        </Box>
+    );
+};
+
+export default Breadcrumbs;

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -21,6 +21,7 @@ import { IconContext } from 'react-icons';
 
 import { setQuestionKeys } from '../redux/app.actions';
 import { CONFIG } from '../utils/constants';
+import Breadcrumbs from './Breadcrumbs';
 
 const QuestionSelector = () => {
     const history = useHistory();
@@ -143,6 +144,7 @@ const QuestionSelector = () => {
 
     return (
         <Box>
+            <Breadcrumbs />
             <HStack>
                 <Heading as='h2' fontWeight='light'>
                     Select questions

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -4,6 +4,8 @@ import { Box, Button, HStack, Text } from '@chakra-ui/react';
 import { useHistory } from 'react-router-dom';
 
 import { DataIndexer } from '../utils';
+import Breadcrumbs from './Breadcrumbs';
+
 const Visualizations = () => {
     const history = useHistory();
     const {
@@ -40,6 +42,7 @@ const Visualizations = () => {
     console.log(categories);
     return (
         <Box>
+            <Breadcrumbs />
             <HStack>
                 <Text>Select Questions</Text>
                 <Button>Save</Button>

--- a/src/app/src/utils/constants.js
+++ b/src/app/src/utils/constants.js
@@ -9,3 +9,9 @@ export const CONFIG = {
     [GEO_REGION]: regionConfig,
     [GEO_COUNTRY]: countryConfig,
 };
+
+export const ROUTES = {
+    HOME: '/',
+    QUESTIONS: '/questions',
+    VISUALIZATIONS: '/visualization',
+};


### PR DESCRIPTION
## Overview

Adds breadcrumbs to the Question and Visualization components.
There's some extra logic to allow us to easily hook them in to
the Saved Charts page when we've built it.

While it might have been possible to create dynamically generated
breadcrumbs, making it a bit more declaratory simplified the code
significantly. Similarly, it would probably be possible to locate this
at the top level instead of in the specific components where it appears,
but because we are only going to be using it on three screens, the
extra logic seemed like an over-complication.

To keep the breadcrumbs and the route paths coordinated, I moved the
route paths to a ROUTES object in the constants file.

Connects #10 

### Demo

<img width="940" alt="Questions" src="https://user-images.githubusercontent.com/21046714/103035044-5add4a80-4534-11eb-9a40-cb8537461d15.png">
<img width="943" alt="Charts" src="https://user-images.githubusercontent.com/21046714/103035050-5d3fa480-4534-11eb-865a-fdb5a8bf0df1.png">

## Testing Instructions

 * Navigate to the homepage. You shouldn't see breadcrumbs.
 * Select a country/region and click next. You should see the Home link and the Questions link. 
 * Select a question and click next. You should see the Home, Questions, and Charts links. 
 * Click the the Charts link - nothing should happen. 
 * Click the Questions link and you should navigate back to the Questions page. 
 * Click the Home link and you should navigate back to the Home page. 
