### PR TITLE
Add Grouped Bar Chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Breadcrumbs [#25](https://github.com/azavea/fb-gender-survey-dashboard/pull/25)
 - Add Stack Chart [#26](https://github.com/azavea/fb-gender-survey-dashboard/pull/26)
+- Add Grouped Bar Chart [#29](https://github.com/azavea/fb-gender-survey-dashboard/pull/29)
 
 ### Changed
 

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -1,8 +1,76 @@
 import React from 'react';
-import { Text } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
+import { ResponsiveBarCanvas } from '@nivo/bar';
 
-const GroupedBarChart = ({ items }) => {
-    return <Text>Grouped Bar Chart</Text>;
+const GroupedBarChart = ({ items, item }) => {
+    const data = items.map(({ response }) => ({
+        ...response,
+        Men: response.male,
+        Women: response.female,
+        Total: response.combined,
+    }));
+    const keys = ['Total', 'Men', 'Women'];
+
+    const { cat, qcode } = items[0].question;
+    const legend = cat ? `Answered "${cat}" to ${qcode}` : `Answered ${qcode}`;
+
+    return (
+        <Box h={250}>
+            <ResponsiveBarCanvas
+                data={data}
+                keys={keys}
+                indexBy='geo'
+                margin={{ top: 50, right: 150, bottom: 50, left: 200 }}
+                pixelRatio={2}
+                padding={0.15}
+                innerPadding={0}
+                minValue='auto'
+                maxValue='auto'
+                groupMode='grouped'
+                layout='horizontal'
+                colors={{ scheme: 'set1' }}
+                axisTop={{
+                    tickSize: 0,
+                    tickPadding: 5,
+                    tickRotation: 0,
+                    format: () => '',
+                    legend,
+                    legendPosition: 'middle',
+                    legendOffset: -15,
+                }}
+                axisBottom={{
+                    tickSize: 5,
+                    tickPadding: 5,
+                    tickRotation: 0,
+                }}
+                theme={{
+                    fontSize: 14,
+                    axis: {
+                        legend: {
+                            text: {
+                                fontSize: 14,
+                                fontWeight: 'bold',
+                                width: 200,
+                            },
+                        },
+                    },
+                }}
+                legends={[
+                    {
+                        dataFrom: 'keys',
+                        anchor: 'top-right',
+                        direction: 'column',
+                        translateX: 120,
+                        translateY: 0,
+                        itemsSpacing: 2,
+                        itemWidth: 100,
+                        itemHeight: 20,
+                        symbolSize: 20,
+                    },
+                ]}
+            />
+        </Box>
+    );
 };
 
 export default GroupedBarChart;


### PR DESCRIPTION
## Overview

Adds the bar chart for grouped responses.

Connects #22 

### Demo

Many countries
<img width="1048" alt="Screen Shot 2020-12-28 at 12 48 36 PM" src="https://user-images.githubusercontent.com/21046714/103233480-42da4200-490b-11eb-8632-a9fa1129d885.png">

Few countries
<img width="1057" alt="Screen Shot 2020-12-28 at 12 48 54 PM" src="https://user-images.githubusercontent.com/21046714/103233484-440b6f00-490b-11eb-90aa-be992454930e.png">

## Notes

The bars auto-resize to fit the height of the container. We could probably calculate a larger height for the container based on the number of countries/regions included if we'd rather the container grow instead of the items shrink. 

## Testing Instructions

 * Select a number of countries or regions
 * Select a question with a bolded answer (ie 'Head of Household')
 * The chart should render the data correctly
 * The chart should show all selected countries
