### PR TITLE
Add app header

### DIFF
--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { ChakraProvider, Heading, Flex } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
 import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import 'focus-visible/dist/focus-visible';
 
 import './App.css';
+import Header from './components/Header';
 import GeographySelector from './components/GeographySelector';
 import QuestionSelector from './components/QuestionSelector';
 import Visualizations from './components/Visualizations';
@@ -35,17 +36,7 @@ function App() {
         <Router>
             <ChakraProvider resetCss theme={theme}>
                 <div className='App'>
-                    <Flex
-                        as='header'
-                        className='App-header'
-                        bg='black'
-                        py='2'
-                        justify='center'
-                    >
-                        <Heading as='h1' fontWeight='light' color='white'>
-                            Gender Equality at Home Dashboard
-                        </Heading>
-                    </Flex>
+                    <Header />
                     <Switch>
                         <Route exact path={ROUTES.HOME}>
                             <GeographySelector />

--- a/src/app/src/components/AboutModal.jsx
+++ b/src/app/src/components/AboutModal.jsx
@@ -1,0 +1,23 @@
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalBody,
+    ModalCloseButton,
+} from '@chakra-ui/react';
+
+const AboutModal = ({ isOpen, onClose }) => {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>About the Survey</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>About content</ModalBody>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default AboutModal;

--- a/src/app/src/components/FaqModal.jsx
+++ b/src/app/src/components/FaqModal.jsx
@@ -1,0 +1,23 @@
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalBody,
+    ModalCloseButton,
+} from '@chakra-ui/react';
+
+const FaqModal = ({ isOpen, onClose }) => {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>FAQ</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>FAQ content</ModalBody>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default FaqModal;

--- a/src/app/src/components/Header.jsx
+++ b/src/app/src/components/Header.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+    Button,
+    HStack,
+    Flex,
+    Heading,
+    Text,
+    VStack,
+    useDisclosure,
+} from '@chakra-ui/react';
+
+import AboutModal from './AboutModal';
+import FaqModal from './FaqModal';
+
+import { ROUTES } from '../utils/constants';
+
+const Header = () => {
+    const { pathname } = useLocation();
+    const isLargeFormat = pathname === ROUTES.HOME;
+    const titleJustify = isLargeFormat ? 'center' : 'flex-start';
+
+    // Manage the visibility state of various modals
+    const {
+        isOpen: faqIsOpen,
+        onOpen: faqOnOpen,
+        onClose: faqOnClose,
+    } = useDisclosure();
+    const {
+        isOpen: aboutIsOpen,
+        onOpen: aboutOnOpen,
+        onClose: aboutOnClose,
+    } = useDisclosure();
+
+    const linkBar = (
+        <Flex justify='flex-end' width='100%'>
+            <HStack spacing='35px' p='2'>
+                <Button color='white' variant='link'>
+                    Saved Charts
+                </Button>
+                <Button color='white' variant='link' onClick={faqOnOpen}>
+                    FAQS
+                </Button>
+                <Button color='white' variant='link' onClick={aboutOnOpen}>
+                    About the Survey
+                </Button>
+            </HStack>
+        </Flex>
+    );
+    const title = (
+        <Heading fontWeight='light'>Dashboard: Gender Equality at Home</Heading>
+    );
+    return (
+        <VStack as='header' className='App-header' bg='black' py='2'>
+            {linkBar}
+            <Flex py='2' width='100%' justify={titleJustify}>
+                <VStack color='white'>
+                    {title}
+                    {isLargeFormat && (
+                        <Text>
+                            How to use the dashboard and nullam quis risus eget
+                            urna mollis ornare vel eu leo. 208 countries &
+                            islands and 80 languages. Maecenas faucibus mollis.
+                        </Text>
+                    )}
+                </VStack>
+                <FaqModal isOpen={faqIsOpen} onClose={faqOnClose} />
+                <AboutModal isOpen={aboutIsOpen} onClose={aboutOnClose} />
+            </Flex>
+        </VStack>
+    );
+};
+
+export default Header;


### PR DESCRIPTION
## Overview

The app header contains two level of hierarchy for titles, as well as a
link bar for navigation or modal dialog display. Add stubs for the two
modals, as well as some basic content manipulation depending on which
page sequence is currently active.

Connects #18 

### Demo

First page, large format:
![image](https://user-images.githubusercontent.com/1014341/103238821-dadf2800-4919-11eb-82a8-5c717c2016ae.png)

Subsequent pages, condensed format
![image](https://user-images.githubusercontent.com/1014341/103238838-edf1f800-4919-11eb-9d93-230637f1c774.png)

### Notes

The visual design feedback doc has a number of header content related changes under discussion, so I opted for a bare-bones implementation for now. There are also two follow up tasks for adding content to the modals (#31) and potentially some dynamic values in the sub-header text (#30). Even though the designs don't indicate it, I believe the "Saved Charts" link will always be present, whether or not there are currently any saved (this is also currently being discussed in the feedback doc).

## Testing Instructions

 * In the deploy preview, ensure that the sub-heading is only visible on the first page
 * Subsequent pages align the main heading to the left
 * All pages have the 3 header links and the two modals will open/close appropriately