### PR TITLE
Persist checkbox state

### DIFF
--- a/src/app/src/components/GeographySelector.jsx
+++ b/src/app/src/components/GeographySelector.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import {
@@ -22,9 +22,22 @@ const GeographySelector = () => {
     const history = useHistory();
     const dispatch = useDispatch();
     const { geoMode, currentGeo } = useSelector(state => state.app);
+    const [prevGeoSelection, setPrevGeoSelection] = useState([]);
 
-    const handleGeoSet = geo => {
-        dispatch(setGeoSelectionMode(geo));
+    const handleGeoSet = newGeoMode => {
+        // Prevent making changes if the user clicked the current geo mode button
+        if (newGeoMode === geoMode) return;
+
+        // Clear out any selected geographies if the user switched modes.
+        // Regions and countries are not able to be selected at the same time.
+        // However, retain the previous mode's selection, so they can be
+        // restored if the mode is switched on again (i.e., the user doesn't
+        // have to reselect them).
+        dispatch(setGeoSelection(prevGeoSelection));
+        setPrevGeoSelection(currentGeo);
+
+        // Set the new geo selection mode
+        dispatch(setGeoSelectionMode(newGeoMode));
     };
 
     const handleSelection = selections => {
@@ -35,9 +48,8 @@ const GeographySelector = () => {
         history.push('/questions');
     };
 
-    // This list of either regions or countries to show
+    // The list of either regions or countries to show
     const geoList = CONFIG[geoMode].geographies;
-
     const section = (
         <Box>
             <HStack>
@@ -83,15 +95,19 @@ const GeographySelector = () => {
                 </Button>
             </Flex>
             <VStack>
-                <CheckboxGroup onChange={handleSelection}>
-                    {geoList.map(r => (
+                <CheckboxGroup
+                    key={`geogroup-${geoMode}`}
+                    onChange={handleSelection}
+                    defaultValue={currentGeo}
+                >
+                    {geoList.map(geo => (
                         <Checkbox
-                            key={`geo-${r}`}
-                            value={r}
+                            key={`geo-${geo}`}
+                            value={geo}
                             size='lg'
                             colorScheme='red'
                         >
-                            {r}
+                            {geo}
                         </Checkbox>
                     ))}
                 </CheckboxGroup>

--- a/src/app/src/components/GeographySelector.jsx
+++ b/src/app/src/components/GeographySelector.jsx
@@ -15,7 +15,11 @@ import {
 import { IoIosArrowRoundForward } from 'react-icons/io';
 import { IconContext } from 'react-icons';
 
-import { setGeoSelection, setGeoSelectionMode } from '../redux/app.actions';
+import {
+    setGeoSelection,
+    setGeoSelectionMode,
+    setQuestionKeys,
+} from '../redux/app.actions';
 import { CONFIG, GEO_COUNTRY, GEO_REGION } from '../utils/constants';
 
 const GeographySelector = () => {
@@ -45,6 +49,10 @@ const GeographySelector = () => {
     };
 
     const handleNext = () => {
+        // Remove any previously selected question keys from state, otherwise
+        // they will be re-rendered when the app navigates to the next section,
+        // and the user will have to uncheck any/all that they don't want.
+        dispatch(setQuestionKeys([]));
         history.push('/questions');
     };
 

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -102,18 +102,22 @@ const QuestionSelector = () => {
         return item.question;
     };
 
+    // Detremine the indexes of any categories that currently have questions
+    // selected. These will be expanded by default.
+    const categoryLetterCodes = Object.values(config.categories);
+    const currentlySelectedCategories = new Set(
+        currentQuestions.map(q => q[0].toUpperCase())
+    );
+    const currentlySelectedCategoryIndexes = Array.from(
+        currentlySelectedCategories
+    ).map(catCode => categoryLetterCodes.indexOf(catCode));
+
     const categories = Object.keys(config.categories).map(cat => {
         const catCode = config.categories[cat];
         const questionCodes = questionsByCategory[catCode];
         const questions = questionCodes.map(q => {
             return (
-                <Checkbox
-                    key={q}
-                    value={q}
-                    defaultIsChecked={q in currentQuestions}
-                    size='lg'
-                    colorScheme='red'
-                >
+                <Checkbox key={q} value={q} size='lg' colorScheme='red'>
                     {getQuestionCheckboxLabel(q)}
                 </Checkbox>
             );
@@ -167,9 +171,15 @@ const QuestionSelector = () => {
                 <CheckboxGroup
                     size='xl'
                     colorScheme='red'
+                    defaultValue={currentQuestions}
                     onChange={handleQuestionSelect}
                 >
-                    <Accordion allowMultiple>{categories}</Accordion>
+                    <Accordion
+                        allowMultiple
+                        defaultIndex={currentlySelectedCategoryIndexes}
+                    >
+                        {categories}
+                    </Accordion>
                 </CheckboxGroup>
             </Box>
         </Box>


### PR DESCRIPTION
## Overview

When returning to the geography selector page, check the boxes that are represented in current state. Additionally, use local state to track the previous "geo selection mode" selected values, so they can be restored when that mode is re-enabled. Prevent both regions and countries from being selected at once.

When navigating back to the question page (from the viz page), select any checkboxes that
match the currently selected state. Additionally, expand any category accordions which have selected checkboxes.

Lastly, now that the user can navigate backwards, it was possible to go from Viz (with questions already selected) back to Geography, and then next to Questions again. This would leave the previously selected questions checked, causing the user to have to manually adjust them. It's not clear which use case we should support (clear them out or save them, either is a convenience depending on the user intent). This commit clears the selection before navigating forwards, but can be removed if the opposite behavior is better received. I think this approach is less error-prone, since the user could have changed the geometry selection mode (e.g., from region --> country) which would invalidate any previously selected questions (since there isn't 100% overlap between region and country questions).

Connects #11 

## Testing Instructions

 * Select several regions - switch to countries, and select several.
 * Switching back and forth should preserve the previous mode's selections, and match that in redux state
 * Move to questions
 * Select several from different categories
 * Move to viz
 * Move back to questions, ensure the questions are selected and the approapriate categories are expanded
 * Move back to geography, select anew, then move to questions
 * Confirm that there is a blank state (both in the UI and redux) for the questions
 * Refresh and ensure _no_ state is preserved
 * Generally use the breadcrumb and browser navigation and determine if the persistence is applied in sensible ways.
