### PR TITLE
Add waffle chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Breadcrumbs [#25](https://github.com/azavea/fb-gender-survey-dashboard/pull/25)
 - Add Stack Chart [#26](https://github.com/azavea/fb-gender-survey-dashboard/pull/26)
 - Add Grouped Bar Chart [#29](https://github.com/azavea/fb-gender-survey-dashboard/pull/29)
+- Add Waffle Chart [#37](https://github.com/azavea/fb-gender-survey-dashboard/pull/37)
 
 ### Changed
 

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -1,8 +1,100 @@
 import React from 'react';
-import { Text } from '@chakra-ui/react';
+import { HStack, Box, Text, Flex } from '@chakra-ui/react';
+import { ResponsiveWaffleCanvas } from '@nivo/waffle';
 
 const WaffleChart = ({ items }) => {
-    return <Text>Waffle Chart</Text>;
+    return items.map(({ question, response }) => {
+        const responses = [
+            [
+                {
+                    id: `Women: ${response.female}`,
+                    label: 'Women',
+                    value: response.female,
+                },
+            ],
+            [
+                {
+                    id: `Men: ${response.male}`,
+                    label: 'Men',
+                    value: response.male,
+                },
+            ],
+            [
+                {
+                    id: `Total: ${response.combined}`,
+                    label: 'Total',
+                    value: response.combined,
+                },
+            ],
+        ];
+        return (
+            <Box
+                mt={4}
+                pt={4}
+                pb={4}
+                borderWidth='1px'
+                borderRadius='lg'
+                key={`${question.qcode}${response.geo}`}
+            >
+                <HStack h={200}>
+                    {responses.map(data => (
+                        <ResponsiveWaffleCanvas
+                            key={`${question.qcode}-${data[0].id}`}
+                            data={data}
+                            pixelRatio={2}
+                            total={10}
+                            rows={2}
+                            columns={5}
+                            padding={5}
+                            margin={{
+                                top: 50,
+                                right: 10,
+                                bottom: 10,
+                                left: 10,
+                            }}
+                            theme={{
+                                fontSize: 14,
+                                legends: {
+                                    text: {
+                                        fontSize: 30,
+                                        width: 200,
+                                    },
+                                },
+                            }}
+                            legends={[
+                                {
+                                    anchor: 'top',
+                                    data: [
+                                        {
+                                            id: 'Total',
+                                            label: 'Total',
+                                            value: response.combined,
+                                        },
+                                    ],
+                                    direction: 'column',
+                                    justify: false,
+                                    translateX: 0,
+                                    translateY: -30,
+                                    itemsSpacing: 4,
+                                    itemWidth: 100,
+                                    itemHeight: 20,
+                                    itemDirection: 'bottom-to-top',
+                                    itemOpacity: 1,
+                                    itemTextColor: '#000',
+                                    symbolSize: 0,
+                                },
+                            ]}
+                        />
+                    ))}
+                </HStack>
+                <Flex justify='center'>
+                    <Text as='strong' size='sm'>
+                        {response.geo}
+                    </Text>
+                </Flex>
+            </Box>
+        );
+    });
 };
 
 export default WaffleChart;


### PR DESCRIPTION
## Overview

Adds a Waffle chart component for displaying 'out of ten' questions. Unlike the bar chart, axis labels aren't available for the Waffle Chart, so I was unable to include the country name in the chart itself. However, I was able to tweak the legend component enough (because the Waffle chart does provide customized legend labels) and use that to create a gender/count label. Note that each gender Waffle chart is a separate canvas element. 

Connects #23 

### Demo

<img width="1350" alt="Screen Shot 2020-12-29 at 9 55 40 AM" src="https://user-images.githubusercontent.com/21046714/103292814-92c51180-49bc-11eb-96d4-2aa6d5ccb48e.png">

## Testing Instructions

 * Select several countries or regions. 
 * Select a few 'out-of-ten' questions.
 * Navigate to the visualizations page and confirm that the chart data and label display the correct information. 
