### PR TITLE
Save visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Stack Chart [#26](https://github.com/azavea/fb-gender-survey-dashboard/pull/26)
 - Add Grouped Bar Chart [#29](https://github.com/azavea/fb-gender-survey-dashboard/pull/29)
 - Add Waffle Chart [#37](https://github.com/azavea/fb-gender-survey-dashboard/pull/37)
+- Save Visualizations [#39](https://github.com/azavea/fb-gender-survey-dashboard/pull/39)
 
 ### Changed
 

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -32,6 +32,7 @@
     "redux-act": "^1.8.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
+    "redux-persist": "^6.0.0",
     "@nivo/core": "^0.67.0",
     "@nivo/bar": "^0.67.0",
     "@nivo/waffle": "^0.67.0"

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import {
     Box,
     Button,
@@ -10,14 +10,18 @@ import {
     Spacer,
 } from '@chakra-ui/react';
 import { useHistory } from 'react-router-dom';
+import { IoIosCheckmark } from 'react-icons/io';
 
 import { CONFIG } from '../utils/constants';
 import { DataIndexer } from '../utils';
+import { saveVisualization } from '../redux/visualizations.actions';
 import Breadcrumbs from './Breadcrumbs';
 import Chart from './Chart';
 
 const Visualizations = () => {
     const history = useHistory();
+    const dispatch = useDispatch();
+    const [isSaved, setSaved] = useState(false);
     const {
         currentQuestions,
         currentGeo,
@@ -52,13 +56,33 @@ const Visualizations = () => {
 
     const config = CONFIG[geoMode];
 
+    const onSaveVisualization = () => {
+        const title = `${currentGeo.join(', ')}`;
+        dispatch(
+            saveVisualization({
+                title,
+                currentQuestions,
+                currentGeo,
+                currentYear,
+                geoMode,
+            })
+        );
+        setSaved(true);
+    };
+
     return (
         <Box>
             <Breadcrumbs />
             <Flex bg='white' p={4} border='1px solid rgb(222, 227, 233)'>
                 <Text fontSize='2xl'>Selected Charts</Text>
                 <Spacer />
-                <Button>Save</Button>
+                {isSaved ? (
+                    <Button leftIcon={<IoIosCheckmark />} isDisabled>
+                        Saved
+                    </Button>
+                ) : (
+                    <Button onClick={onSaveVisualization}>Save</Button>
+                )}
             </Flex>
             <Text p={4}>
                 Showing charts for: {currentGeo.join(', ')} •{' '}

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -1,17 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 
 import './index.css';
 import App from './App';
 import configureStore from './redux/store';
 
-const { store } = configureStore();
+const { store, persistor } = configureStore();
+
 ReactDOM.render(
     <Provider store={store}>
-        <React.StrictMode>
-            <App />
-        </React.StrictMode>
+        <PersistGate loading={null} persistor={persistor}>
+            <React.StrictMode>
+                <App />
+            </React.StrictMode>
+        </PersistGate>
     </Provider>,
     document.getElementById('root')
 );

--- a/src/app/src/redux/reducers.js
+++ b/src/app/src/redux/reducers.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 
 import AppReducer from './app.reducer';
+import VisualizationsReducer from './visualizations.reducer';
 
 export default combineReducers({
     app: AppReducer,
+    visualizations: VisualizationsReducer,
 });

--- a/src/app/src/redux/store.js
+++ b/src/app/src/redux/store.js
@@ -1,8 +1,18 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 import reducers from './reducers';
+
+const persistConfig = {
+    key: 'root',
+    storage,
+    whitelist: ['visualizations'],
+};
+
+const persistedReducer = persistReducer(persistConfig, reducers);
 
 const middlewares = [thunk];
 
@@ -13,11 +23,12 @@ if (process.env.NODE_ENV === 'development') {
 
 const configureStore = () => {
     const store = applyMiddleware(...middlewares)(createStore)(
-        reducers,
+        persistedReducer,
         window.__REDUX_DEVTOOLS_EXTENSION__ &&
             window.__REDUX_DEVTOOLS_EXTENSION__()
     );
-    return { store };
+    const persistor = persistStore(store);
+    return { store, persistor };
 };
 
 export { configureStore as default };

--- a/src/app/src/redux/visualizations.actions.js
+++ b/src/app/src/redux/visualizations.actions.js
@@ -1,0 +1,3 @@
+import { createAction } from 'redux-act';
+
+export const saveVisualization = createAction('Save visualization');

--- a/src/app/src/redux/visualizations.reducer.js
+++ b/src/app/src/redux/visualizations.reducer.js
@@ -1,0 +1,14 @@
+import { createReducer } from 'redux-act';
+import produce from 'immer';
+import { saveVisualization } from './visualizations.actions';
+
+export const initialState = Object.freeze([]);
+
+export default createReducer(
+    {
+        [saveVisualization]: produce((state, payload) => {
+            state.push(payload);
+        }),
+    },
+    initialState
+);

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -2205,7 +2205,7 @@
     d3-time-format "^2.1.3"
     react-spring "9.0.0-rc.3"
 
-"@nivo/bar@^0.31.0":
+"@nivo/bar@^0.67.0":
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/@nivo/bar/-/bar-0.67.0.tgz#b60b5f246014f09c32688e78adc0ffb33f841381"
   integrity sha512-Y8sIN3iW6r1nS/bWXkSOuWR1mekkVI0yF0uo0IHIXRA+cvhwSChYuH8nIKFbaSd4f4DM3SCogFoGj5ILooRneg==
@@ -2233,7 +2233,7 @@
     lodash "^4.17.11"
     react-motion "^0.5.2"
 
-"@nivo/core@^0.31.0":
+"@nivo/core@^0.67.0":
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/@nivo/core/-/core-0.67.0.tgz#29f07b8bed2bcefb9402d14a9abe2895c5b2bfa2"
   integrity sha512-F8amsf/MnIuZLoN6ikla8bKlUkUI3HVhy6R2qMF2jDS5xnYch3Sno9OPTTuR8RnYGCr57yClnvFuJzw251GE6g==
@@ -2275,7 +2275,7 @@
   dependencies:
     react-spring "9.0.0-rc.3"
 
-"@nivo/waffle@^0.31.0":
+"@nivo/waffle@^0.67.0":
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/@nivo/waffle/-/waffle-0.67.0.tgz#bc3afc44c9c0f0f8b4339ebe6fef6ff72c841265"
   integrity sha512-tXkNBhQhoAvCtLe9DsuGPn5jva6PjiA90oNkIlJueTMYqB6OwPdYnMX3f3/Tp8heFWXrkT2ZjJZ6J6Ja2zYJXQ==
@@ -11065,6 +11065,11 @@ redux-logger@^3.0.6:
   integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
   dependencies:
     deep-diff "^0.3.5"
+
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
 redux-thunk@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Overview

Users are able to click 'save' while on the visualizations page,
and store their currently selected geographies/questions/etc. into
local storage.

Data is stored in an array of objects, with each object containing a
title and the information needed to recreate the visualization. 

The stored visualization does NOT include the survey data, which means 
that we don't capture stale state data if the dataset changes. 
However, when completing the follow-up UI tasks we will need to 
gracefully handle cases where a persisted question or geography 
is no longer available.

Connects #19 

### Demo

<img width="935" alt="Screen Shot 2020-12-29 at 12 17 59 PM" src="https://user-images.githubusercontent.com/21046714/103303737-c01db980-49d4-11eb-8392-e387515a6fa5.png">

## Testing Instructions

 * Select geographies and questions, then click 'save' on the visualizations page. 
 * View Redux state and local storage and confirm that the visualization data has been added. 
 * Add additional visualizations and confirm they are added. 
 * Refresh the page and ensure the visualizations are loaded into state. 
