### PR TITLE
View saved visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Grouped Bar Chart [#29](https://github.com/azavea/fb-gender-survey-dashboard/pull/29)
 - Add Waffle Chart [#37](https://github.com/azavea/fb-gender-survey-dashboard/pull/37)
 - Save Visualizations [#39](https://github.com/azavea/fb-gender-survey-dashboard/pull/39)
+- View Visualizations [#45](https://github.com/azavea/fb-gender-survey-dashboard/pull/45)
 
 ### Changed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -9,6 +9,7 @@ import Header from './components/Header';
 import GeographySelector from './components/GeographySelector';
 import QuestionSelector from './components/QuestionSelector';
 import Visualizations from './components/Visualizations';
+import SavedVisualizations from './components/SavedVisualizations';
 import theme from './theme';
 
 import { setData } from './redux/app.actions';
@@ -46,6 +47,9 @@ function App() {
                         </Route>
                         <Route path={ROUTES.VISUALIZATIONS}>
                             <Visualizations />
+                        </Route>
+                        <Route path={ROUTES.SAVED}>
+                            <SavedVisualizations />
                         </Route>
                     </Switch>
                 </div>

--- a/src/app/src/components/EditableTitle.js
+++ b/src/app/src/components/EditableTitle.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import {
+    Flex,
+    IconButton,
+    Editable,
+    EditableInput,
+    EditablePreview,
+    ButtonGroup,
+} from '@chakra-ui/react';
+import { IoMdCreate, IoIosCheckmark } from 'react-icons/io';
+
+import { renameVisualization } from '../redux/visualizations.actions';
+
+function EditableControls({ isEditing, onSubmit, onEdit }) {
+    return isEditing ? (
+        <ButtonGroup
+            alignItems='center'
+            ml={4}
+            onClick={e => e.stopPropagation()}
+        >
+            <IconButton
+                size='sm'
+                isRound
+                icon={<IoIosCheckmark />}
+                onClick={onSubmit}
+                fontSize='2xl'
+            />
+        </ButtonGroup>
+    ) : (
+        <Flex
+            alignItems='center'
+            ml={4}
+            minWidth='32px'
+            onClick={e => e.stopPropagation()}
+        >
+            <IconButton
+                size='sm'
+                isRound
+                icon={<IoMdCreate />}
+                onClick={onEdit}
+                display='none'
+                _groupHover={{ display: 'flex' }}
+            />
+        </Flex>
+    );
+}
+
+function EditableTitle({ title, index }) {
+    const dispatch = useDispatch();
+
+    const onSubmit = value => {
+        dispatch(renameVisualization({ title: value, index }));
+    };
+
+    // 'stopPropagation' needs to be used on several subcomponents to prevent
+    // clicks on the buttons and within the input from navigating the user
+    // to the saved visualization.
+    return (
+        <Editable
+            textAlign='left'
+            defaultValue={title}
+            color='rgb(39, 55, 63)'
+            fontSize='2xl'
+            isPreviewFocusable={false}
+            display='flex'
+            flex={1}
+            alignContent='center'
+            align='center'
+            role='group'
+            onSubmit={onSubmit}
+        >
+            {props => (
+                <>
+                    <EditablePreview />
+                    <EditableInput onClick={e => e.stopPropagation()} />
+                    <EditableControls {...props} />
+                </>
+            )}
+        </Editable>
+    );
+}
+
+export default EditableTitle;

--- a/src/app/src/components/Header.jsx
+++ b/src/app/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import {
     Button,
     HStack,
@@ -35,7 +35,12 @@ const Header = () => {
     const linkBar = (
         <Flex justify='flex-end' width='100%'>
             <HStack spacing='35px' p='2'>
-                <Button color='white' variant='link'>
+                <Button
+                    color='white'
+                    variant='link'
+                    as={Link}
+                    to={ROUTES.SAVED}
+                >
                     Saved Charts
                 </Button>
                 <Button color='white' variant='link' onClick={faqOnOpen}>

--- a/src/app/src/components/SavedVisualizations.js
+++ b/src/app/src/components/SavedVisualizations.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { Box, Text, Flex, Spacer, IconButton } from '@chakra-ui/react';
+import { useHistory } from 'react-router-dom';
+import { IoIosArrowRoundForward, IoIosTrash } from 'react-icons/io';
+
+import { ROUTES } from '../utils/constants';
+import { setVisualization } from '../redux/app.actions';
+import { deleteVisualization } from '../redux/visualizations.actions';
+import Breadcrumbs from './Breadcrumbs';
+import EditableTitle from './EditableTitle';
+
+const SavedVisualizations = () => {
+    const history = useHistory();
+    const dispatch = useDispatch();
+    const visualizations = useSelector(state => state.visualizations);
+
+    const onClickList = visualization => {
+        dispatch(setVisualization(visualization));
+        history.push(ROUTES.VISUALIZATIONS);
+    };
+
+    const renderSavedVisualization = (
+        { title, currentQuestions, currentGeo, currentYear, geoMode },
+        index
+    ) => (
+        <Flex
+            bg='white'
+            p={4}
+            m={4}
+            borderRadius='sm'
+            role='button'
+            onClick={() =>
+                onClickList({
+                    currentQuestions,
+                    currentGeo,
+                    currentYear,
+                    geoMode,
+                })
+            }
+            direction='column'
+            key={`${index}-${title}`}
+        >
+            <Flex flex={1}>
+                <Flex flex={1}>
+                    <EditableTitle title={title} index={index} />
+                </Flex>
+                <Flex alignItems='center' ml={4}>
+                    <Text fontSize='3xl'>
+                        <IoIosArrowRoundForward />
+                    </Text>
+                </Flex>
+            </Flex>
+            <Flex role='group'>
+                <Text>{currentQuestions.length} questions</Text>
+                <Spacer />
+                <Text fontSize='3xl'>
+                    <IconButton
+                        aria-label='Delete visualization'
+                        icon={<IoIosTrash />}
+                        onClick={e => {
+                            e.stopPropagation();
+                            dispatch(deleteVisualization(index));
+                        }}
+                    />
+                </Text>
+            </Flex>
+        </Flex>
+    );
+
+    return (
+        <Box>
+            <Breadcrumbs />
+            <Flex bg='white' p={4} border='1px solid rgb(222, 227, 233)'>
+                <Text fontSize='2xl'>Saved Charts</Text>
+            </Flex>
+            <Box p={4}>
+                {visualizations.length ? (
+                    visualizations.map(renderSavedVisualization)
+                ) : (
+                    <Flex
+                        bg='white'
+                        p={4}
+                        m={4}
+                        borderRadius='sm'
+                        as='button'
+                        onClick={() => history.push(ROUTES.HOME)}
+                    >
+                        <Text fontSize='3xl'>
+                            You have no saved charts yet. Click the 'Save'
+                            button on the visualization page in order to keep
+                            track of them here.
+                        </Text>
+                    </Flex>
+                )}
+            </Box>
+        </Box>
+    );
+};
+
+export default SavedVisualizations;

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
     Box,
@@ -30,6 +30,11 @@ const Visualizations = () => {
         data,
     } = useSelector(state => state.app);
 
+    // Scroll to top on initial page load
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
     // If a page reloads directly to this page, restart at home
     if (!currentQuestions.length || !currentGeo.length) {
         history.push('/');
@@ -39,6 +44,7 @@ const Visualizations = () => {
     const categorize = questionSet => {
         const questionsByCategory = { A: [], B: [], C: [], D: [] };
         questionSet.forEach(qs => {
+            if (!qs[0].question) return;
             // All responses in a questionset are in the same category. Take the
             // first, and map it to a category key
             const key = qs[0].question.qcode[0].toUpperCase();

--- a/src/app/src/redux/app.actions.js
+++ b/src/app/src/redux/app.actions.js
@@ -4,3 +4,4 @@ export const setData = createAction('Set data');
 export const setGeoSelectionMode = createAction('Set geo selection mode');
 export const setGeoSelection = createAction('Set geo selection');
 export const setQuestionKeys = createAction('Set question keys');
+export const setVisualization = createAction('Set visualization');

--- a/src/app/src/redux/app.reducer.js
+++ b/src/app/src/redux/app.reducer.js
@@ -1,4 +1,5 @@
 import { createReducer } from 'redux-act';
+import produce from 'immer';
 import { merge, set } from '../utils';
 import { GEO_REGION } from '../utils/constants';
 
@@ -7,6 +8,7 @@ import {
     setGeoSelection,
     setGeoSelectionMode,
     setQuestionKeys,
+    setVisualization,
 } from './app.actions';
 
 export const initialState = Object.freeze({
@@ -23,6 +25,12 @@ export default createReducer(
         [setGeoSelection]: set('currentGeo'),
         [setGeoSelectionMode]: set('geoMode'),
         [setQuestionKeys]: set('currentQuestions'),
+        [setVisualization]: produce((state, payload) => {
+            state.geoMode = payload.geoMode;
+            state.currentYear = payload.currentYear;
+            state.currentGeo = payload.currentGeo;
+            state.currentQuestions = payload.currentQuestions;
+        }),
     },
     initialState
 );

--- a/src/app/src/redux/visualizations.actions.js
+++ b/src/app/src/redux/visualizations.actions.js
@@ -1,3 +1,5 @@
 import { createAction } from 'redux-act';
 
 export const saveVisualization = createAction('Save visualization');
+export const renameVisualization = createAction('Rename visualization');
+export const deleteVisualization = createAction('Delete visualization');

--- a/src/app/src/redux/visualizations.reducer.js
+++ b/src/app/src/redux/visualizations.reducer.js
@@ -1,6 +1,10 @@
 import { createReducer } from 'redux-act';
 import produce from 'immer';
-import { saveVisualization } from './visualizations.actions';
+import {
+    saveVisualization,
+    renameVisualization,
+    deleteVisualization,
+} from './visualizations.actions';
 
 export const initialState = Object.freeze([]);
 
@@ -8,6 +12,12 @@ export default createReducer(
     {
         [saveVisualization]: produce((state, payload) => {
             state.push(payload);
+        }),
+        [renameVisualization]: produce((state, payload) => {
+            state[payload.index].title = payload.title;
+        }),
+        [deleteVisualization]: produce((state, payload) => {
+            state.splice(payload, 1);
         }),
     },
     initialState

--- a/src/app/src/utils/constants.js
+++ b/src/app/src/utils/constants.js
@@ -14,4 +14,5 @@ export const ROUTES = {
     HOME: '/',
     QUESTIONS: '/questions',
     VISUALIZATIONS: '/visualization',
+    SAVED: '/saved',
 };

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -56,6 +56,9 @@ export class DataIndexer {
 
     formatForViz(key, geo) {
         const resp = this.survey[key];
+        if (!resp) {
+            return { key, geo };
+        }
         const idx = resp.idx;
         const d = this.data.geographies[geo];
         const c = d['Combined'][idx];


### PR DESCRIPTION
## Overview

Allows users to manage saved visualizations. Users can load the visualizations' list from local storage, edit their titles, and navigate to a specific visualization.

Connects #20 

### Demo

<img width="1392" alt="Screen Shot 2020-12-30 at 11 43 33 AM" src="https://user-images.githubusercontent.com/21046714/103367930-477e3200-4a94-11eb-866f-95bd39661136.png">

## Testing Instructions

 * Select 'saved charts' in the header. 
 * You should see a list of saved charts.
 * Hover over the title of one chart, then click the edit button.
 * You should be able to edit the title in an inline input, then click submit. On refreshing the page, the title should remain edited. 
 * You should be able to edit the title, then click cancel. The title should revert to its previous state. 
 * You should be able to click within the list item, outside of the buttons or input, to be taken to the saved visualization.
 * The questions and geographies for the saved visualization should match the stored values. 
 * Add an invalid question id to the list of currentQuestions in a stored list. When loading the list, valid questions should load, and the invalid question should be ignored. 
