### PR TITLE
Allow production releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,50 @@
+---
+name: Release
+about: When ready to cut a release
+title: Release X.Y.Z
+labels: release
+assignees: ""
+---
+
+## Overview
+
+Releases for this frontend only app require that commits in `develop` are
+merged to `master`. Netlify manages the CI and deploy process when new
+commits are added to `master`. These instructions assume the `git flow` tool
+is installed on your workstation, and the default values applied from `git flow init`.
+
+Substitute `X.Y.Z` below for the version for this release.
+
+## Steps
+
+- [ ] Test the staging site to ensure it is ready for production
+- [ ] Start a new release branch:
+
+```bash
+git flow release start X.Y.Z
+```
+
+- [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
+- [ ] Ensure outstanding changes are committed:
+
+```bash
+git status # Is the git staging area clean?
+git add CHANGELOG.md
+git commit -m "X.Y.Z"
+```
+
+- [ ] Publish the release branch:
+
+```bash
+git flow release publish X.Y.Z
+```
+
+- [ ] Finish and publish the release branch:
+  - When prompted, keep default commit messages
+  - Use `X.Y.Z` as the tag message
+
+```bash
+git flow release finish -p X.Y.Z
+```
+
+- [ ] Test the production site

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Interactive exploration of global results from the Facebook "Survey on Gender Equality At Home".
 
-Original data set:
-<https://data.humdata.org/dataset/survey-on-gender-equality-at-home>
+Important links:
 
-Survey results report
-<https://dataforgood.fb.com/docs/gendersurveyreport/>
+- Staging site: <https://develop--gender-survey-dashboard.netlify.app/>
+- Production site: <https://gender-survey-dashboard.netlify.app/>
+- Original data set: <https://data.humdata.org/dataset/survey-on-gender-equality-at-home>
+- Survey results report <https://dataforgood.fb.com/docs/gendersurveyreport/>
 
 ## Requirements
 


### PR DESCRIPTION
## Overview

The contents of this PR add documentation and instruction on how to create and manage production releases. It is expected that future planned release will create a new `Release` issue and follow the instructions.

Separately, the following were also done to enable production releases:
- Added a `master` branch
- Set `master` as the production branch in the Netlify settings for this site
- Moved `develop` to and "additional" deployment site in the Netlify settings
- Followed the instructions in the release template to cut an initial release at 0.1.0

Going forward, merging into `develop` should deploy to https://develop--gender-survey-dashboard.netlify.app/ and cutting a release (which merges `develop` -> `master`) should deploy to https://gender-survey-dashboard.netlify.app/. PR deploy previews should continue to function as-is.

Connects #42 

## Testing Instructions

 * Visit the two URLs listed above and verify they match the features in each respective branch (the branches may be equivalent when viewing, since I just cut a release prior to opening this PR)
 * Review the release instructions and ensure they make sense