### PR TITLE
Filter Questions and Geographies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a 404 page [#51](https://github.com/azavea/fb-gender-survey-dashboard/pull/51)
+- Add search for countries and questions [#50](https://github.com/azavea/fb-gender-survey-dashboard/pull/50)
 
 ### Changed
 

--- a/src/app/src/components/GeographySelector.jsx
+++ b/src/app/src/components/GeographySelector.jsx
@@ -7,10 +7,10 @@ import {
     Button,
     Checkbox,
     CheckboxGroup,
-    HStack,
     Text,
     Heading,
     VStack,
+    Spacer,
 } from '@chakra-ui/react';
 import { IoIosArrowRoundForward } from 'react-icons/io';
 import { IconContext } from 'react-icons';
@@ -21,12 +21,15 @@ import {
     setQuestionKeys,
 } from '../redux/app.actions';
 import { CONFIG, GEO_COUNTRY, GEO_REGION } from '../utils/constants';
+import { formatQuery } from '../utils';
+import SearchInput from './SearchInput';
 
 const GeographySelector = () => {
     const history = useHistory();
     const dispatch = useDispatch();
     const { geoMode, currentGeo } = useSelector(state => state.app);
     const [prevGeoSelection, setPrevGeoSelection] = useState([]);
+    const [query, setQuery] = useState('');
 
     const handleGeoSet = newGeoMode => {
         // Prevent making changes if the user clicked the current geo mode button
@@ -57,13 +60,23 @@ const GeographySelector = () => {
     };
 
     // The list of either regions or countries to show
-    const geoList = CONFIG[geoMode].geographies;
+    let geoList = CONFIG[geoMode].geographies;
+
+    if (query.trim().length && geoMode === GEO_COUNTRY) {
+        geoList = geoList.filter(
+            g =>
+                formatQuery(g).includes(formatQuery(query)) ||
+                currentGeo.includes(g)
+        );
+    }
+
     const section = (
         <Box>
-            <HStack>
+            <Flex m={4}>
                 <Heading as='h2' fontWeight='light'>
                     Choose one or more areas to analyze
                 </Heading>
+                <Spacer />
                 <Button
                     colorScheme='red'
                     rightIcon={
@@ -76,50 +89,66 @@ const GeographySelector = () => {
                 >
                     Next
                 </Button>
-            </HStack>
-            <Flex alignItems='baseline'>
-                <Button
-                    variant='link'
-                    size='lg'
-                    onClick={() => handleGeoSet(GEO_REGION)}
-                >
-                    REGIONS
-                </Button>
-                <Text
-                    fontSize='sm'
-                    textTransform='uppercase'
-                    mx='2'
-                    color='gray.600'
-                    fontWeight='medium'
-                >
-                    or
-                </Text>
-                <Button
-                    variant='link'
-                    size='lg'
-                    onClick={() => handleGeoSet(GEO_COUNTRY)}
-                >
-                    COUNTRIES
-                </Button>
             </Flex>
-            <VStack>
-                <CheckboxGroup
-                    key={`geogroup-${geoMode}`}
-                    onChange={handleSelection}
-                    defaultValue={currentGeo}
-                >
-                    {geoList.map(geo => (
-                        <Checkbox
-                            key={`geo-${geo}`}
-                            value={geo}
+            <Flex ml={4}>
+                <Flex flex={1} direction='column'>
+                    <Flex alignItems='baseline' m={4}>
+                        <Button
+                            variant='link'
                             size='lg'
-                            colorScheme='red'
+                            onClick={() => handleGeoSet(GEO_REGION)}
                         >
-                            {geo}
-                        </Checkbox>
-                    ))}
-                </CheckboxGroup>
-            </VStack>
+                            REGIONS
+                        </Button>
+                        <Text
+                            fontSize='sm'
+                            textTransform='uppercase'
+                            mx='2'
+                            color='gray.600'
+                            fontWeight='medium'
+                        >
+                            or
+                        </Text>
+                        <Button
+                            variant='link'
+                            size='lg'
+                            onClick={() => handleGeoSet(GEO_COUNTRY)}
+                        >
+                            COUNTRIES
+                        </Button>
+                    </Flex>
+                    {geoMode === GEO_COUNTRY && (
+                        <SearchInput
+                            query={query}
+                            setQuery={setQuery}
+                            placeholder='Filter countries'
+                        />
+                    )}
+                    <VStack align='start' m={4}>
+                        <CheckboxGroup
+                            key={`geogroup-${geoMode}`}
+                            onChange={handleSelection}
+                            defaultValue={currentGeo}
+                        >
+                            {geoList.length ? (
+                                geoList.map(geo => (
+                                    <Checkbox
+                                        key={`geo-${geo}`}
+                                        value={geo}
+                                        size='lg'
+                                        colorScheme='red'
+                                    >
+                                        {geo}
+                                    </Checkbox>
+                                ))
+                            ) : (
+                                <Text>No areas found.</Text>
+                            )}
+                        </CheckboxGroup>
+                    </VStack>
+                </Flex>
+                <Flex flex={2} />
+            </Flex>
         </Box>
     );
     return section;

--- a/src/app/src/components/SearchInput.js
+++ b/src/app/src/components/SearchInput.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+    Box,
+    Text,
+    Input,
+    InputGroup,
+    InputLeftElement,
+} from '@chakra-ui/react';
+import { IoIosSearch } from 'react-icons/io';
+
+const SearchInput = ({ query, setQuery, placeholder }) => {
+    return (
+        <Box m={4}>
+            <InputGroup bg='white'>
+                <InputLeftElement
+                    pointerEvents='none'
+                    children={
+                        <Text color='gray.300' fontSize='1rem'>
+                            <IoIosSearch />
+                        </Text>
+                    }
+                />
+                <Input
+                    value={query}
+                    onChange={e => setQuery(e.target.value)}
+                    placeholder={placeholder}
+                />
+            </InputGroup>
+        </Box>
+    );
+};
+
+export default SearchInput;

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -90,3 +90,5 @@ export class DataIndexer {
         return rest;
     }
 }
+
+export const formatQuery = str => str?.trim().toLowerCase() || '';


### PR DESCRIPTION
## Overview

Allows the list of geographies or questions to be narrowed down to labels which contain the user input.

For the list of geographies, if a user selects an item and then changes the search term, the selected item is shown regardless of if it matches the current query. Text is shown to indicate no results found.

For the list of questions, questions are shown if the question or the answer/cat matches. If no matches are found for a category, that category is replaced by text stating that no results were found. 

Connects #24 

### Demo

Filtered results + previously selected
<img width="646" alt="Screen Shot 2021-01-04 at 10 29 05 AM" src="https://user-images.githubusercontent.com/21046714/103553218-242ffa00-4e7b-11eb-99af-501e8007ff0b.png">

No results
<img width="626" alt="Screen Shot 2021-01-04 at 10 28 32 AM" src="https://user-images.githubusercontent.com/21046714/103553201-1ed2af80-4e7b-11eb-88d8-0720fa5c256e.png">

Filtered Questions
<img width="1359" alt="Screen Shot 2021-01-04 at 10 26 43 AM" src="https://user-images.githubusercontent.com/21046714/103553167-111d2a00-4e7b-11eb-8dbc-0f3ffd7a5605.png">

Questions with some empty sections
<img width="1361" alt="Screen Shot 2021-01-04 at 10 26 33 AM" src="https://user-images.githubusercontent.com/21046714/103553127-02367780-4e7b-11eb-8f04-4bb172b6e6d9.png">

## Testing Instructions

 * Open the Netlify preview. 
 * Enter a search term and confirm the list of regions is filtered. Select a region. 
 * Enter a new region. The list should be filtered but the selected region should remain. 
 * Enter a search term that gets no results and confirm that 'no results' text is shown. 
 * Switch to countries and repeat the steps above. 
 * Go to questions and enter a search term. Questions should be filtered by the term entered. 
 * Enter a term that matches no questions for a particular section. That section should be replaced by 'not found' text.
