### PR TITLE
Add a 404 Not Found Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a 404 page [#51](https://github.com/azavea/fb-gender-survey-dashboard/pull/51)
+
 ### Changed
 
 ### Fixed

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -10,6 +10,7 @@ import GeographySelector from './components/GeographySelector';
 import QuestionSelector from './components/QuestionSelector';
 import Visualizations from './components/Visualizations';
 import SavedVisualizations from './components/SavedVisualizations';
+import NotFound from './components/NotFound';
 import theme from './theme';
 
 import { setData } from './redux/app.actions';
@@ -50,6 +51,9 @@ function App() {
                         </Route>
                         <Route path={ROUTES.SAVED}>
                             <SavedVisualizations />
+                        </Route>
+                        <Route>
+                            <NotFound />
                         </Route>
                     </Switch>
                 </div>

--- a/src/app/src/components/NotFound.js
+++ b/src/app/src/components/NotFound.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { Heading, Text, VStack, Link, Icon } from '@chakra-ui/react';
+import { IoIosArrowRoundBack } from 'react-icons/io';
+
+const NotFound = () => (
+    <VStack spacing={4} margin={8}>
+        <Heading size='xl'>404</Heading>
+        <Heading as='h2' size='2xl'>
+            Something's missing.
+        </Heading>
+        <Text>
+            The page you're looking for doesn't exist, or the link you followed
+            was incorrect.
+        </Text>
+        <Link as={RouterLink} to='/'>
+            <Icon as={IoIosArrowRoundBack} /> Go back home
+        </Link>
+    </VStack>
+);
+
+export default NotFound;


### PR DESCRIPTION
## Overview

Adds a page for attempts to access routes which don't exist.

Connects #46 

### Demo

<img width="1352" alt="Screen Shot 2021-01-04 at 1 41 01 PM" src="https://user-images.githubusercontent.com/21046714/103567833-80524880-4e92-11eb-93d3-72f0f1794220.png">

## Testing Instructions

 * Open the Netlify preview. 
 * Enter a route that doesn't exist, such as '/test'
 * The 404 page should show
 * Follow the link to home on the 404 page
 * Traverse the real routes and confirm that the app works as before
