### PR TITLE
Download chart as PNG image option

### DIFF
--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -8,3 +8,11 @@
   outline: none;
   box-shadow: none;
 }
+
+div.download-menu {
+  visibility: hidden;
+}
+
+div.chart-container:hover  div.download-menu {
+  visibility: visible;
+}

--- a/src/app/src/components/Chart.js
+++ b/src/app/src/components/Chart.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Text } from '@chakra-ui/react';
+
 import StackedBarChart from './StackedBarChart';
 import WaffleChart from './WaffleChart';
 import GroupedBarChart from './GroupedBarChart';

--- a/src/app/src/components/DownloadMenu.jsx
+++ b/src/app/src/components/DownloadMenu.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import {
+    Flex,
+    IconButton,
+    Menu,
+    MenuButton,
+    MenuList,
+    MenuItem,
+} from '@chakra-ui/react';
+import { FaDownload } from 'react-icons/fa';
+import { combineCanvases, setBackgroundColor } from '../utils/canvas';
+
+const download = (dataUrl, filename, filetype = 'png') => {
+    var dl = document.createElement('a');
+    document.body.appendChild(dl); // This line makes it work in Firefox.
+    dl.setAttribute('href', dataUrl);
+    dl.setAttribute('download', `${filename}.${filetype}`);
+    dl.click();
+    dl.remove();
+};
+
+const createFilename = questionAttrs => {
+    // Assemble a file name from question components
+    const { cat, geo, qcode, question } = questionAttrs;
+    const catDisplay = cat ? `${cat}_` : '';
+    const geoDisplay = geo ? `${geo}_` : '';
+    return `${qcode}_${geoDisplay}${catDisplay}${question}`;
+};
+
+const DownloadMenu = ({
+    question,
+    chartContainerRef,
+    combineDir = 'horizontal',
+}) => {
+    const saveImage = () => {
+        // Use the ref for the chart container to find the canvas DOM element,
+        // which is the chart itself
+        const chartCanvases = chartContainerRef.current.querySelectorAll(
+            'canvas'
+        );
+
+        const filename = createFilename(question);
+
+        // Depending on the chart type, there may be many canvas elements.
+        // Coerce them into a single canvas, or if just one, use it directly.
+        const chartCanvas =
+            chartCanvases.length > 1
+                ? combineCanvases(chartCanvases, combineDir)
+                : chartCanvases[0];
+
+        // Set a white background instead of the default transparent
+        const newCanvas = setBackgroundColor(chartCanvas, '#FFF');
+
+        // Convert the entire new canvas to a base64 data URL
+        const dataUrl = newCanvas.toDataURL('image/png');
+
+        download(dataUrl, filename);
+    };
+
+    return (
+        <Flex className='download-menu'>
+            <Menu isLazy>
+                <MenuButton
+                    as={IconButton}
+                    ml='auto'
+                    aria-label='download chart image'
+                    isRound={true}
+                    icon={<FaDownload />}
+                />
+                <MenuList>
+                    <MenuItem onClick={saveImage}>PNG</MenuItem>
+                    <MenuItem>CSV</MenuItem>
+                </MenuList>
+            </Menu>
+        </Flex>
+    );
+};
+
+export default DownloadMenu;

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Box } from '@chakra-ui/react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
 
-const GroupedBarChart = ({ items, item }) => {
+import DownloadMenu from './DownloadMenu';
+
+const GroupedBarChart = ({ items }) => {
     const data = items.map(({ response }) => ({
         ...response,
         Men: response.male,
@@ -14,8 +16,14 @@ const GroupedBarChart = ({ items, item }) => {
     const { cat, qcode } = items[0].question;
     const legend = cat ? `Answered "${cat}" to ${qcode}` : `Answered ${qcode}`;
 
+    const containerRef = useRef();
+
     return (
-        <Box h={250}>
+        <Box className='chart-container' h={250} ref={containerRef}>
+            <DownloadMenu
+                chartContainerRef={containerRef}
+                question={items[0].question}
+            />
             <ResponsiveBarCanvas
                 data={data}
                 keys={keys}

--- a/src/app/src/components/StackedBarChart.js
+++ b/src/app/src/components/StackedBarChart.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { Box } from '@chakra-ui/react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
+import DownloadMenu from './DownloadMenu';
+import useRefs from '../hooks/useRefs';
 
 const StackedBarChart = ({ items }) => {
-    return items.map(({ question, responses }) => {
+    const containerRefs = useRefs(items.length);
+
+    return items.map(({ question, responses }, i) => {
         const data = responses.reduce(
             (acc, curr) => {
                 acc[0][curr.cat] = Math.round(curr.combined, 2);
@@ -16,7 +20,17 @@ const StackedBarChart = ({ items }) => {
         const keys = responses.map(r => r.cat);
 
         return (
-            <Box h={250} key={`${question.question.qcode}-${responses[0].geo}`}>
+            <Box
+                h={270}
+                className='chart-container'
+                key={`${question.question.qcode}-${responses[0].geo}`}
+                ref={containerRefs.current[i]}
+                pb={10}
+            >
+                <DownloadMenu
+                    chartContainerRef={containerRefs.current[i]}
+                    question={{ ...question, geo: responses[0].geo }}
+                />
                 <ResponsiveBarCanvas
                     data={data}
                     keys={keys}

--- a/src/app/src/components/StackedBarChart.js
+++ b/src/app/src/components/StackedBarChart.js
@@ -23,7 +23,7 @@ const StackedBarChart = ({ items }) => {
             <Box
                 h={270}
                 className='chart-container'
-                key={`${question.question.qcode}-${responses[0].geo}`}
+                key={`stacked-${question.question.qcode}-${responses[0].geo}`}
                 ref={containerRefs.current[i]}
                 pb={10}
             >

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -40,7 +40,7 @@ const WaffleChart = ({ items }) => {
                 borderWidth='1px'
                 borderRadius='lg'
                 className='chart-container'
-                key={`${question.qcode}${response.geo}`}
+                key={`waffle-${question.qcode}${response.geo}`}
                 ref={containerRefs.current[i]}
             >
                 <DownloadMenu
@@ -51,6 +51,7 @@ const WaffleChart = ({ items }) => {
                     {responses.map(data => (
                         <ResponsiveWaffleCanvas
                             data={data}
+                            key={`waffle-${question.qcode}${response.geo}${data[0].label}`}
                             pixelRatio={2}
                             total={10}
                             rows={2}

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -2,8 +2,13 @@ import React from 'react';
 import { HStack, Box, Text, Flex } from '@chakra-ui/react';
 import { ResponsiveWaffleCanvas } from '@nivo/waffle';
 
+import DownloadMenu from './DownloadMenu';
+import useRefs from '../hooks/useRefs';
+
 const WaffleChart = ({ items }) => {
-    return items.map(({ question, response }) => {
+    const containerRefs = useRefs(items.length);
+
+    return items.map(({ question, response }, i) => {
         const responses = [
             [
                 {
@@ -34,12 +39,17 @@ const WaffleChart = ({ items }) => {
                 pb={4}
                 borderWidth='1px'
                 borderRadius='lg'
+                className='chart-container'
                 key={`${question.qcode}${response.geo}`}
+                ref={containerRefs.current[i]}
             >
+                <DownloadMenu
+                    chartContainerRef={containerRefs.current[i]}
+                    question={{ ...question, geo: response.geo }}
+                />
                 <HStack h={200}>
                     {responses.map(data => (
                         <ResponsiveWaffleCanvas
-                            key={`${question.qcode}-${data[0].id}`}
                             data={data}
                             pixelRatio={2}
                             total={10}

--- a/src/app/src/hooks/useRefs.js
+++ b/src/app/src/hooks/useRefs.js
@@ -1,0 +1,17 @@
+import React, { useRef } from 'react';
+
+// A custom hook that creates an array of refs equaling the number of array
+// elements passed to it. Useful for creating refs to be used inside of a loop
+// where useRef is not valid.
+const useRefs = length => {
+    const containerRefs = useRef([]);
+    if (containerRefs.current.length !== length) {
+        containerRefs.current = Array(length)
+            .fill()
+            .map((_, i) => containerRefs.current[i] || React.createRef());
+    }
+
+    return containerRefs;
+};
+
+export default useRefs;

--- a/src/app/src/utils/canvas.js
+++ b/src/app/src/utils/canvas.js
@@ -1,0 +1,32 @@
+export const combineCanvases = (canvasList, direction) => {
+    if (direction === 'horizontal') {
+        return combineHorizontal(canvasList);
+    } else {
+        new Error(`Combine type: ${direction} not implemented`);
+    }
+};
+
+export const combineHorizontal = canvasList => {
+    const chartCanvas = document.createElement('canvas');
+    chartCanvas.width = canvasList[0].width * canvasList.length;
+    chartCanvas.height = canvasList[0].height;
+
+    const newCtx = chartCanvas.getContext('2d');
+    canvasList.forEach((c, i) => {
+        newCtx.drawImage(c, 0 + c.width * i, 0);
+    });
+
+    return chartCanvas;
+};
+
+export const setBackgroundColor = (canvas, color) => {
+    // Nivo canvas charts have a transparent background. Create a new canvas
+    // and set a white background. Copy the canvas chart on top of it.
+    const newCanvas = canvas.cloneNode(true);
+    const ctx = newCanvas.getContext('2d');
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, newCanvas.width, newCanvas.height);
+    ctx.drawImage(canvas, 0, 0);
+
+    return newCanvas;
+};


### PR DESCRIPTION
## Overview

All of the Nivo chart types implemented in the app render to Canvas. As
a result, we can generate a dataUrl for each canvas element and offer it
as a direct image download. A new button is available on every individual
chart (or chart group in the case of Waffle) which gives a menu to download
 the image as PNG.  

A few workarounds are needed to accomplish
this:

- A ref to a particular container element is required in order to
generically search for a child canvas element
- Waffle charts are really a sequence of three separate charts that
should be treated as one
- Nivo charts have a transparent background, and a solid color needs to
be applied before writing

As a result of these extra requirements, there is some manual
manipulation of the canvas element to represent enough chart context to
be meaningful. Some content, like a title or geography, is not included
on the canvas based on the chart type. In these cases, I've made the
filename the place where _all_ data shows up. As an enhancement, we may
need to include additional text directly on the chart canvas while
generating the image.

Connects #48 


### Notes

While all relevant information is included in the file name, it would be nice to ensure it is included in the image content directly. This is related to #27 and may not be possible in the current scope.

The CSV menu item was added, but it is not implemented.

More charts _could_ be combined (like Stacked), but it's not entirely clear if it's desirable. I'm interested in client feedback about the utility of downloading select charts instead of big chunks of them. They may be embedded in other media better by remaining per-geography or group.

## Testing Instructions

 * For multiple geographies, select multiple questions of each chart type
 * Check each chart or chart group has a new hover-only button for a download menu
 * Clicking the download PNG option saves a PNG to the local machine which includes a representative rendering of the selected chart. 
 * The generated file name includes enough context to be able to associate the chart with a question. 
