### PR TITLE
Visualizations Page Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Clean up of visualizations page [#55](https://github.com/azavea/fb-gender-survey-dashboard/pull/55)
+
 ### Removed
 
 ## 0.1.0

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -41,7 +41,9 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "lint": "eslint ./src --ext .js --ext .jsx"
+    "lint": "eslint ./src --ext .js --ext .jsx",
+    "react-spring-issue-1078": "find node_modules -path \\*@react-spring/\\*/package.json -exec sed -i.bak 's/\"sideEffects\": false/\"sideEffects\": true/g' {} +",
+    "postinstall": "npm run react-spring-issue-1078"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -5,12 +5,14 @@ import { ResponsiveBarCanvas } from '@nivo/bar';
 import DownloadMenu from './DownloadMenu';
 
 const GroupedBarChart = ({ items }) => {
-    const data = items.map(({ response }) => ({
-        ...response,
-        Men: response.male,
-        Women: response.female,
-        Total: response.combined,
-    }));
+    const data = items
+        .map(({ response }) => ({
+            ...response,
+            Men: response.male,
+            Women: response.female,
+            Total: response.combined,
+        }))
+        .reverse();
     const keys = ['Total', 'Men', 'Women'];
 
     const { cat, qcode } = items[0].question;

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -95,27 +95,31 @@ const Visualizations = () => {
                 {currentQuestions.length} questions
             </Text>
             <Box>
-                {Object.keys(config.categories).map(cat => (
-                    <Box key={cat}>
-                        <HStack
-                            align='center'
-                            justify='center'
-                            spacing={2}
-                            p={4}
-                        >
-                            <Text casing='uppercase' whiteSpace='nowrap'>
-                                {cat}
-                            </Text>
-                            <Divider />
-                        </HStack>
-                        {categories[config.categories[cat]].map(items => (
-                            <Chart
-                                items={items}
-                                key={items[0].question.qcode}
-                            />
-                        ))}
-                    </Box>
-                ))}
+                {Object.keys(config.categories).map(cat => {
+                    const questions = categories[config.categories[cat]];
+                    if (!questions.length) return null;
+                    return (
+                        <Box key={cat}>
+                            <HStack
+                                align='center'
+                                justify='center'
+                                spacing={2}
+                                p={4}
+                            >
+                                <Text casing='uppercase' whiteSpace='nowrap'>
+                                    {cat}
+                                </Text>
+                                <Divider />
+                            </HStack>
+                            {questions.map(items => (
+                                <Chart
+                                    items={items}
+                                    key={items[0].question.qcode}
+                                />
+                            ))}
+                        </Box>
+                    );
+                })}
             </Box>
         </Box>
     );

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -61,9 +61,9 @@ export class DataIndexer {
         }
         const idx = resp.idx;
         const d = this.data.geographies[geo];
-        const c = d['Combined'][idx];
-        const m = d['Male'][idx];
-        const f = d['Female'][idx];
+        const c = d['Combined'][idx].toFixed(2);
+        const m = d['Male'][idx].toFixed(2);
+        const f = d['Female'][idx].toFixed(2);
 
         return {
             key: key,


### PR DESCRIPTION
## Overview

- Nivo tooltips move with cursor locally and when deployed
- Round values to hundredths
- Hide empty chart categories
- Maintain consistent order of regions for charts

Connects #38 

### Demo

Rounded values
<img width="1267" alt="Screen Shot 2021-01-05 at 3 01 43 PM" src="https://user-images.githubusercontent.com/21046714/103777740-566a6480-4fff-11eb-8ea0-2c84f41c47f6.png">

Grouped chart with correct ordering
<img width="1234" alt="Screen Shot 2021-01-05 at 3 14 32 PM" src="https://user-images.githubusercontent.com/21046714/103777744-579b9180-4fff-11eb-92a9-e63ea3e36b32.png">

Hidden empty sections
<img width="1261" alt="Screen Shot 2021-01-05 at 3 18 43 PM" src="https://user-images.githubusercontent.com/21046714/103777749-58ccbe80-4fff-11eb-802c-abf24e057a2d.png">

## Testing Instructions

 * In the deploy preview, select multiple regions and at least one question of each chart type. Don't select questions from every category.
 * Move your cursor around on the charts and confirm the tooltip follows your cursor.
 * Confirm the values in the tooltips have two decimal places.
 * Confirm that the order of the regions is the same for each chart type. 
 * Confirm that the categories with no selected questions are hidden. 
