### PR TITLE
Handle Percentage Charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Handle Percentage Charts [#58](https://github.com/azavea/fb-gender-survey-dashboard/pull/58)
+
 ### Fixed
 
 - Clean up of visualizations page [#55](https://github.com/azavea/fb-gender-survey-dashboard/pull/55)

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -15,7 +15,11 @@ const GroupedBarChart = ({ items }) => {
         .reverse();
     const keys = ['Total', 'Men', 'Women'];
 
-    const { cat, qcode } = items[0].question;
+    const { cat, qcode, type } = items[0].question;
+    const isPercent = type === 'pct';
+    const formatValue = v =>
+        isPercent ? `${v}%` : parseFloat(v).toLocaleString();
+
     const legend = cat ? `Answered "${cat}" to ${qcode}` : `Answered ${qcode}`;
 
     const containerRef = useRef();
@@ -35,7 +39,7 @@ const GroupedBarChart = ({ items }) => {
                 padding={0.15}
                 innerPadding={0}
                 minValue='auto'
-                maxValue='auto'
+                maxValue={isPercent ? 100 : 'auto'}
                 groupMode='grouped'
                 layout='horizontal'
                 colors={{ scheme: 'set1' }}
@@ -52,7 +56,9 @@ const GroupedBarChart = ({ items }) => {
                     tickSize: 5,
                     tickPadding: 5,
                     tickRotation: 0,
+                    format: formatValue,
                 }}
+                tooltipFormat={formatValue}
                 theme={{
                     fontSize: 14,
                     axis: {

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -76,6 +76,11 @@ const Visualizations = () => {
         setSaved(true);
     };
 
+    const createKey = items =>
+        items[0].response
+            ? `${items[0].response.key}-${items[0].response.geo}`
+            : `${items[0].responses[0].key}-${items[0].responses[0].geo}`;
+
     return (
         <Box>
             <Breadcrumbs />
@@ -112,10 +117,7 @@ const Visualizations = () => {
                                 <Divider />
                             </HStack>
                             {questions.map(items => (
-                                <Chart
-                                    items={items}
-                                    key={items[0].question.qcode}
-                                />
+                                <Chart items={items} key={createKey(items)} />
                             ))}
                         </Box>
                     );


### PR DESCRIPTION
## Overview

More clearly expresses the data in percentage charts by setting their
limit to 100, and formatting ticks and tooltips as percentages.

Adds locale formatting to non-percentage grouped bar charts.

Also switches the format of keys for charts to prevent duplicate key
warnings.

Connects #56 

### Demo

<img width="1220" alt="Screen Shot 2021-01-06 at 11 21 40 AM" src="https://user-images.githubusercontent.com/21046714/103797207-2da19980-5016-11eb-98f9-51108f101462.png">
<img width="1265" alt="Screen Shot 2021-01-06 at 11 22 53 AM" src="https://user-images.githubusercontent.com/21046714/103797217-2f6b5d00-5016-11eb-8864-e3afd64ab4a5.png">

### Notes

We chose to leave the current types as-is, even though `hours` and `null` type charts are handled identically at the moment, in order to allow for differentiation in the future if desired. 

## Testing Instructions

 * In the deploy preview, select several percentage-type questions, hours-type questions, and null-type questions. 
 * Confirm that the percentage charts show percentages in the axis and the tooltip, and that they are set to limits of 0%-100%.
 * Confirm that the hours- and null-type questions are working as before with auto-calculated limits, and that the numbers are formatted reasonably. 
