### PR TITLE
Download CSVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a 404 page [#51](https://github.com/azavea/fb-gender-survey-dashboard/pull/51)
 - Add search for countries and questions [#50](https://github.com/azavea/fb-gender-survey-dashboard/pull/50)
 - Allow Question Category Select-All/None [#68](https://github.com/azavea/fb-gender-survey-dashboard/pull/68)
+- Download CSVs [#67](https://github.com/azavea/fb-gender-survey-dashboard/pull/67)
 
 ### Changed
 

--- a/src/app/src/components/DownloadMenu.jsx
+++ b/src/app/src/components/DownloadMenu.jsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { FaDownload } from 'react-icons/fa';
 import { combineCanvases, setBackgroundColor } from '../utils/canvas';
+import { downloadCSV } from '../utils/csv';
 
 const download = (dataUrl, filename, filetype = 'png') => {
     var dl = document.createElement('a');
@@ -32,6 +33,7 @@ const DownloadMenu = ({
     question,
     chartContainerRef,
     combineDir = 'horizontal',
+    csvData,
 }) => {
     const saveImage = () => {
         // Use the ref for the chart container to find the canvas DOM element,
@@ -58,6 +60,8 @@ const DownloadMenu = ({
         download(dataUrl, filename);
     };
 
+    const saveCSV = () => downloadCSV(csvData);
+
     return (
         <Flex className='download-menu'>
             <Menu isLazy>
@@ -70,7 +74,7 @@ const DownloadMenu = ({
                 />
                 <MenuList>
                     <MenuItem onClick={saveImage}>PNG</MenuItem>
-                    <MenuItem>CSV</MenuItem>
+                    <MenuItem onClick={saveCSV}>CSV</MenuItem>
                 </MenuList>
             </Menu>
         </Flex>

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -3,6 +3,7 @@ import { Box } from '@chakra-ui/react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
 
 import DownloadMenu from './DownloadMenu';
+import { formatGroupedCSV } from '../utils/csv';
 
 const GroupedBarChart = ({ items }) => {
     const data = items
@@ -29,6 +30,7 @@ const GroupedBarChart = ({ items }) => {
             <DownloadMenu
                 chartContainerRef={containerRef}
                 question={items[0].question}
+                csvData={formatGroupedCSV(items)}
             />
             <ResponsiveBarCanvas
                 data={data}

--- a/src/app/src/components/StackedBarChart.js
+++ b/src/app/src/components/StackedBarChart.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Box } from '@chakra-ui/react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
+
 import DownloadMenu from './DownloadMenu';
 import useRefs from '../hooks/useRefs';
+import { formatStackedCSV } from '../utils/csv';
 
 const StackedBarChart = ({ items }) => {
     const containerRefs = useRefs(items.length);
@@ -30,6 +32,7 @@ const StackedBarChart = ({ items }) => {
                 <DownloadMenu
                     chartContainerRef={containerRefs.current[i]}
                     question={{ ...question, geo: responses[0].geo }}
+                    csvData={formatStackedCSV({ question, responses })}
                 />
                 <ResponsiveBarCanvas
                     data={data}

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
     Box,
+    ButtonGroup,
     Button,
     HStack,
     Text,
@@ -10,10 +11,11 @@ import {
     Spacer,
 } from '@chakra-ui/react';
 import { useHistory } from 'react-router-dom';
-import { IoIosCheckmark } from 'react-icons/io';
+import { IoIosCheckmark, IoIosStar, IoMdDownload } from 'react-icons/io';
 
 import { CONFIG } from '../utils/constants';
 import { DataIndexer } from '../utils';
+import { downloadVisualizationsCSV } from '../utils/csv';
 import { saveVisualization } from '../redux/visualizations.actions';
 import Breadcrumbs from './Breadcrumbs';
 import Chart from './Chart';
@@ -62,6 +64,10 @@ const Visualizations = () => {
 
     const config = CONFIG[geoMode];
 
+    const onDownloadCSV = () => {
+        downloadVisualizationsCSV(categories);
+    };
+
     const onSaveVisualization = () => {
         const title = `${currentGeo.join(', ')}`;
         dispatch(
@@ -87,13 +93,32 @@ const Visualizations = () => {
             <Flex bg='white' p={4} border='1px solid rgb(222, 227, 233)'>
                 <Text fontSize='2xl'>Selected Charts</Text>
                 <Spacer />
-                {isSaved ? (
-                    <Button leftIcon={<IoIosCheckmark />} isDisabled>
-                        Saved
+                <ButtonGroup spacing='4' fontWeight='bold'>
+                    <Button
+                        leftIcon={<IoMdDownload />}
+                        onClick={onDownloadCSV}
+                        fontWeight='bold'
+                    >
+                        Download CSV
                     </Button>
-                ) : (
-                    <Button onClick={onSaveVisualization}>Save</Button>
-                )}
+                    {isSaved ? (
+                        <Button
+                            leftIcon={<IoIosCheckmark />}
+                            fontWeight='bold'
+                            isDisabled
+                        >
+                            Saved
+                        </Button>
+                    ) : (
+                        <Button
+                            leftIcon={<IoIosStar />}
+                            onClick={onSaveVisualization}
+                            fontWeight='bold'
+                        >
+                            Save
+                        </Button>
+                    )}
+                </ButtonGroup>
             </Flex>
             <Text p={4}>
                 Showing charts for: {currentGeo.join(', ')} •{' '}

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -4,6 +4,7 @@ import { ResponsiveWaffleCanvas } from '@nivo/waffle';
 
 import DownloadMenu from './DownloadMenu';
 import useRefs from '../hooks/useRefs';
+import { formatWaffleCSV } from '../utils/csv';
 
 const WaffleChart = ({ items }) => {
     const containerRefs = useRefs(items.length);
@@ -46,6 +47,7 @@ const WaffleChart = ({ items }) => {
                 <DownloadMenu
                     chartContainerRef={containerRefs.current[i]}
                     question={{ ...question, geo: response.geo }}
+                    csvData={formatWaffleCSV({ question, response })}
                 />
                 <HStack h={200}>
                     {responses.map(data => (

--- a/src/app/src/utils/csv.js
+++ b/src/app/src/utils/csv.js
@@ -1,0 +1,100 @@
+const csvHeader = [
+    'Geography',
+    'Question Code',
+    'Question Text',
+    'Response Category',
+    'Response Variable',
+    'Gender',
+    'Value',
+];
+
+const addCSVResponse = ({ question, response, data }) => {
+    // This order must match the header columns
+    const row = [
+        response.geo,
+        question.qcode,
+        question.question,
+        response.cat,
+        response.key,
+    ];
+
+    data.push([...row, 'male', response.male]);
+    data.push([...row, 'female', response.female]);
+    data.push([...row, 'combined', response.combined]);
+};
+
+export const formatWaffleCSV = (item, data = []) => {
+    addCSVResponse({ ...item, data });
+
+    return data;
+};
+
+export const formatStackedCSV = (item, data = []) => {
+    const { question, responses } = item;
+
+    responses.forEach(response => {
+        addCSVResponse({ question, response, data });
+    });
+
+    return data;
+};
+
+export const formatGroupedCSV = (items, data = []) => {
+    items.forEach(item => {
+        addCSVResponse({ ...item, data });
+    });
+
+    return data;
+};
+
+export const downloadVisualizationsCSV = categories => {
+    let data = [];
+    Object.keys(categories).forEach(cat => {
+        categories[cat].forEach(items => {
+            if (items[0].question.type === 'stack') {
+                items.forEach(item => {
+                    data = formatStackedCSV(item, data);
+                });
+            } else {
+                items.forEach(item => {
+                    addCSVResponse({ ...item, data });
+                });
+            }
+        });
+    });
+
+    data.sort((a, b) => (a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0));
+
+    downloadCSV(data);
+};
+
+const createFilename = csvData => {
+    let filename = '';
+    csvData.forEach(row => {
+        const qcode = row[1];
+        if (!filename.includes(qcode)) {
+            filename += `${qcode}_`;
+        }
+    });
+    return `${filename}gender_survey.csv`;
+};
+
+// For null/false cells, numeric cells, etc. do nothing.
+// For string cells, wrap cell in quotes.
+const wrapStringCellInQuotes = cell =>
+    !cell || !isNaN(cell) ? cell : `"${cell}"`;
+
+export const downloadCSV = csvData => {
+    const filename = createFilename(csvData);
+    let csvContent =
+        'data:text/csv;charset=utf-8,' +
+        [csvHeader, ...csvData]
+            .map(e => e.map(wrapStringCellInQuotes).join(','))
+            .join('\n');
+
+    var hiddenElement = document.createElement('a');
+    hiddenElement.href = encodeURI(csvContent);
+    hiddenElement.target = '_blank';
+    hiddenElement.download = filename;
+    hiddenElement.click();
+};


### PR DESCRIPTION
## Overview

Users can download selections of the data for each chart or for the
visualizations page as a whole. The chart contains the columns
Geography, Question Code, Question Text, Response Category,
Response Variable, Gender, and Value, with a varying number of rows
per chart type. The filename contains the question codes for the
requested data, ie `A.1_B.1_gender_survey.csv`.

Connects #59 

### Demo

Stacked
<img width="803" alt="Screen Shot 2021-01-08 at 9 09 40 AM" src="https://user-images.githubusercontent.com/21046714/104060059-58c9eb80-51c4-11eb-9dc2-072a0ef82354.png">

Waffle
<img width="801" alt="Screen Shot 2021-01-08 at 9 10 47 AM" src="https://user-images.githubusercontent.com/21046714/104060104-6bdcbb80-51c4-11eb-9998-659135617a31.png">

Grouped
<img width="887" alt="Screen Shot 2021-01-08 at 9 27 12 AM" src="https://user-images.githubusercontent.com/21046714/104060111-7008d900-51c4-11eb-903a-be3e948b88bc.png">

All Selected Questions
<img width="974" alt="Screen Shot 2021-01-08 at 10 19 53 AM" src="https://user-images.githubusercontent.com/21046714/104060134-78611400-51c4-11eb-9b30-2a8b92429fb2.png">

## Testing Instructions

 * In the deploy preview, select multiple regions and multiple questions (at least one question of each type).
 * For each chart, download the CSV. Confirm that the data is correct and is formatted correctly, and the filename makes sense. 
 * Click the 'download' button at the top of the page. Confirm that the data and filename are correct. 
 * Test in multiple browsers if possible (I've tested Firefox, Safari, and Chrome). 
