### PR TITLE
Allow Question Category Select-All/None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a 404 page [#51](https://github.com/azavea/fb-gender-survey-dashboard/pull/51)
 - Add search for countries and questions [#50](https://github.com/azavea/fb-gender-survey-dashboard/pull/50)
+- Allow Question Category Select-All/None [#68](https://github.com/azavea/fb-gender-survey-dashboard/pull/68)
 
 ### Changed
 


### PR DESCRIPTION
## Overview

Allows users to select/deselect all questions in a category by toggling
the category checkbox.

Connects #60 

### Demo

![Checks](https://user-images.githubusercontent.com/21046714/104222950-016c8b00-5411-11eb-8bb1-2d0945d8a5c3.gif)

## Testing Instructions

 * In the deploy preview, select a region or country and continue to questions. 
 * Open a category and select a question. The category should move to an indeterminate checkbox. 
 * Select the category checkbox. All questions in the category should be selected. 
 * Deselect one question in the category. The category should move to an indeterminate state. 
 * Reselect the question and the checkbox should move to a selected state. 
 * Deselect the checkbox. All questions in the category should be deselected. 
 * Manually select all questions in the category. The category should be marked selected. 
 * Manually deselect all questions in the category. The category should be marked unselected. 
 * Select/deselect various combinations of categories and questions across categories; the selection should behave as expected across categories. 