### PR TITLE
Text Copy and Header Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Handle Percentage Charts [#58](https://github.com/azavea/fb-gender-survey-dashboard/pull/58)
+- Update Text Copy and Header [#70](https://github.com/azavea/fb-gender-survey-dashboard/pull/70)
 
 ### Fixed
 

--- a/src/app/src/components/GeographySelector.jsx
+++ b/src/app/src/components/GeographySelector.jsx
@@ -74,7 +74,7 @@ const GeographySelector = () => {
         <Box>
             <Flex m={4}>
                 <Heading as='h2' fontWeight='light'>
-                    Choose one or more areas to analyze
+                    Start by selecting Regions or Countries
                 </Heading>
                 <Spacer />
                 <Button

--- a/src/app/src/components/Header.jsx
+++ b/src/app/src/components/Header.jsx
@@ -8,6 +8,8 @@ import {
     Text,
     VStack,
     useDisclosure,
+    Link as ChakraLink,
+    Spacer,
 } from '@chakra-ui/react';
 
 import AboutModal from './AboutModal';
@@ -33,8 +35,28 @@ const Header = () => {
     } = useDisclosure();
 
     const linkBar = (
-        <Flex justify='flex-end' width='100%'>
-            <HStack spacing='35px' p='2'>
+        <Flex justify='space-between' width='100%'>
+            {!isLargeFormat ? (
+                <Heading
+                    align='flex-start'
+                    fontWeight='500'
+                    color='white'
+                    maxWidth='790px'
+                    fontSize='22px'
+                    m={4}
+                >
+                    Survey on Gender Equality at Home
+                </Heading>
+            ) : (
+                <Spacer />
+            )}
+            <HStack spacing='35px' p='2' mr={4}>
+                <Button color='white' variant='link' onClick={faqOnOpen}>
+                    FAQS
+                </Button>
+                <Button color='white' variant='link' onClick={aboutOnOpen}>
+                    About the Survey
+                </Button>
                 <Button
                     color='white'
                     variant='link'
@@ -43,35 +65,51 @@ const Header = () => {
                 >
                     Saved Charts
                 </Button>
-                <Button color='white' variant='link' onClick={faqOnOpen}>
-                    FAQS
-                </Button>
-                <Button color='white' variant='link' onClick={aboutOnOpen}>
-                    About the Survey
-                </Button>
             </HStack>
         </Flex>
     );
-    const title = (
-        <Heading fontWeight='light'>Dashboard: Gender Equality at Home</Heading>
-    );
-    return (
-        <VStack as='header' className='App-header' bg='black' py='2'>
-            {linkBar}
-            <Flex py='2' width='100%' justify={titleJustify}>
-                <VStack color='white'>
-                    {title}
-                    {isLargeFormat && (
-                        <Text>
-                            How to use the dashboard and nullam quis risus eget
-                            urna mollis ornare vel eu leo. 208 countries &
-                            islands and 80 languages. Maecenas faucibus mollis.
+
+    if (isLargeFormat) {
+        return (
+            <VStack
+                as='header'
+                className='App-header'
+                bg='linear-gradient(-225deg, rgb(26, 43, 51) 0%, rgb(1, 16, 23) 100%)'
+                py='2'
+            >
+                {linkBar}
+                <Flex py='2' width='100%' justify={titleJustify}>
+                    <VStack color='white' maxWidth='790px' m={4} spacing={4}>
+                        <Text casing='uppercase'>Dashboard</Text>
+                        <Heading fontWeight='light'>
+                            Survey on Gender Equality at Home
+                        </Heading>
+                        <Text fontSize='18px'>
+                            Explore the aggregate data of the Survey on Gender
+                            Equality at Home issued in July 2020 in over 80
+                            languages to more than 460,000 Facebook users in all
+                            world regions.{' '}
+                            <ChakraLink
+                                href='https://data.humdata.org/dataset/survey-on-gender-equality-at-home'
+                                color='#f3a48e'
+                                isExternal
+                            >
+                                View the full aggregate dataset here.
+                            </ChakraLink>
                         </Text>
-                    )}
-                </VStack>
-                <FaqModal isOpen={faqIsOpen} onClose={faqOnClose} />
-                <AboutModal isOpen={aboutIsOpen} onClose={aboutOnClose} />
-            </Flex>
+                    </VStack>
+                    <FaqModal isOpen={faqIsOpen} onClose={faqOnClose} />
+                    <AboutModal isOpen={aboutIsOpen} onClose={aboutOnClose} />
+                </Flex>
+            </VStack>
+        );
+    }
+
+    return (
+        <VStack as='header' className='App-header' bg='rgb(26, 43, 51)' py='2'>
+            {linkBar}
+            <FaqModal isOpen={faqIsOpen} onClose={faqOnClose} />
+            <AboutModal isOpen={aboutIsOpen} onClose={aboutOnClose} />
         </VStack>
     );
 };

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -16,13 +16,13 @@ import {
     Heading,
     VStack,
     Flex,
-    Spacer,
+    Link,
 } from '@chakra-ui/react';
 import { IoIosArrowRoundForward } from 'react-icons/io';
 import { IconContext } from 'react-icons';
 
 import { setQuestionKeys } from '../redux/app.actions';
-import { CONFIG } from '../utils/constants';
+import { CONFIG, ROUTES } from '../utils/constants';
 import { formatQuery } from '../utils';
 import Breadcrumbs from './Breadcrumbs';
 import SearchInput from './SearchInput';
@@ -100,7 +100,7 @@ const QuestionSelector = () => {
     };
 
     const handleNext = () => {
-        history.push('/visualization');
+        history.push(ROUTES.VISUALIZATIONS);
     };
 
     Object.entries(config.survey).forEach(([key, question]) => {
@@ -265,12 +265,29 @@ const QuestionSelector = () => {
             </HStack>
             <Flex m={4}>
                 <Text size='2xl'>{currentGeo.join(', ')}</Text>
-                <Spacer />
-                <SearchInput
-                    query={query}
-                    setQuery={setQuery}
-                    placeholder='Filter questions'
-                />
+            </Flex>
+            <Flex m={4} align='center'>
+                <Flex flex={1} mr={4}>
+                    <Text>
+                        The survey was structured into four sections to
+                        understand a snapshot of gender equality during
+                        Covid-19.{' '}
+                        <Link
+                            href='https://dataforgood.fb.com/wp-content/uploads/2020/09/Survey-on-Gender-Equality-at-Home-Report-1.pdf#page=60'
+                            textDecoration='underline'
+                            isExternal
+                        >
+                            View the full survey here.
+                        </Link>
+                    </Text>
+                </Flex>
+                <Flex flex={1}>
+                    <SearchInput
+                        query={query}
+                        setQuery={setQuery}
+                        placeholder='Filter questions'
+                    />
+                </Flex>
             </Flex>
             <Box>
                 <CheckboxGroup

--- a/src/app/src/components/SavedVisualizations.js
+++ b/src/app/src/components/SavedVisualizations.js
@@ -71,8 +71,18 @@ const SavedVisualizations = () => {
     return (
         <Box>
             <Breadcrumbs />
-            <Flex bg='white' p={4} border='1px solid rgb(222, 227, 233)'>
+            <Flex
+                bg='white'
+                p={4}
+                border='1px solid rgb(222, 227, 233)'
+                align='baseline'
+            >
                 <Text fontSize='2xl'>Saved Charts</Text>
+                <Spacer />
+                <Text>
+                    Charts are saved locally in your browser. Clearing your
+                    browser data may impact this page.
+                </Text>
             </Flex>
             <Box p={4}>
                 {visualizations.length ? (
@@ -88,8 +98,8 @@ const SavedVisualizations = () => {
                     >
                         <Text fontSize='3xl'>
                             You have no saved charts yet. Click the 'Save'
-                            button on the visualization page in order to keep
-                            track of them here.
+                            button on the charts page in order to keep track of
+                            them here.
                         </Text>
                     </Flex>
                 )}

--- a/src/app/src/components/SearchInput.js
+++ b/src/app/src/components/SearchInput.js
@@ -10,7 +10,7 @@ import { IoIosSearch } from 'react-icons/io';
 
 const SearchInput = ({ query, setQuery, placeholder }) => {
     return (
-        <Box m={4}>
+        <Box m={4} flex={1}>
             <InputGroup bg='white'>
                 <InputLeftElement
                     pointerEvents='none'

--- a/src/app/src/utils/constants.js
+++ b/src/app/src/utils/constants.js
@@ -13,6 +13,6 @@ export const CONFIG = {
 export const ROUTES = {
     HOME: '/',
     QUESTIONS: '/questions',
-    VISUALIZATIONS: '/visualization',
+    VISUALIZATIONS: '/charts',
     SAVED: '/saved',
 };


### PR DESCRIPTION
## Overview

Updates large and small version of header to more closely match
current designs.

Updates text throughout website, specifically:
- Change "Choose one or more areas to analyze" to "Start by selecting
Regions or Countries".
- Update subtext under main title, per Dashboard text doc.
- Add explanatory text above the question categories
- Add text above the saved charts tiles explaining that deleting cookies
can impact saved charts
- Call charts "charts" (not visualizations) on saved charts page

Connects #62 

### Demo

<img width="1403" alt="Screen Shot 2021-01-12 at 1 29 28 PM" src="https://user-images.githubusercontent.com/21046714/104361370-5b885180-54e0-11eb-9ff3-3056c528be2f.png">
<img width="1406" alt="Screen Shot 2021-01-12 at 1 29 48 PM" src="https://user-images.githubusercontent.com/21046714/104361403-63e08c80-54e0-11eb-8e3a-4d9faed73645.png">
<img width="1409" alt="Screen Shot 2021-01-12 at 1 30 02 PM" src="https://user-images.githubusercontent.com/21046714/104361411-680caa00-54e0-11eb-91dc-8a0b2c832fdd.png">

## Testing Instructions

 * In Netflify preview, confirm that the header text and style on the geographies page matches the mockups and [feedback document](https://docs.google.com/spreadsheets/d/1jeDH5uchMijCl4gXCEs-LHNEmVcAx-mYhoIb1S8XVC0/edit#gid=0). 
 * On the questions page, confirm that the header style and the explanatory text match the mockups and feedback document. 
 * On the Saved Charts page, confirm that there is a note explaining the storage system and that the message for no stored charts says 'charts page,' not 'visualizations page.'
