### PR TITLE
Add modal content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add search for countries and questions [#50](https://github.com/azavea/fb-gender-survey-dashboard/pull/50)
 - Allow Question Category Select-All/None [#68](https://github.com/azavea/fb-gender-survey-dashboard/pull/68)
 - Download CSVs [#67](https://github.com/azavea/fb-gender-survey-dashboard/pull/67)
+- Add Modal Content [#71](https://github.com/azavea/fb-gender-survey-dashboard/pull/71)
 
 ### Changed
 

--- a/src/app/src/components/AboutModal.jsx
+++ b/src/app/src/components/AboutModal.jsx
@@ -5,16 +5,186 @@ import {
     ModalHeader,
     ModalBody,
     ModalCloseButton,
+    Accordion,
 } from '@chakra-ui/react';
+
+import { StyledAccordionItem, StyledLink, StyledText } from './StyledAccordion';
 
 const AboutModal = ({ isOpen, onClose }) => {
     return (
-        <Modal isOpen={isOpen} onClose={onClose}>
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            size='xl'
+            scrollBehavior='inside'
+        >
             <ModalOverlay />
             <ModalContent>
                 <ModalHeader>About the Survey</ModalHeader>
                 <ModalCloseButton />
-                <ModalBody>About content</ModalBody>
+                <ModalBody>
+                    <Accordion allowToggle>
+                        <StyledAccordionItem title='About the Survey on Gender Equality at Home'>
+                            <StyledText>
+                                In July 2020, approximately half a million
+                                people in 208 countries, territories and islands
+                                were surveyed on Facebook to capture household
+                                gender dynamics during the COVID-19 pandemic.
+                                The data provides a global snapshot to help
+                                researchers, NGOs, global development
+                                institutions, and gender equality advocates
+                                identify and track trends and progress towards
+                                the UN Sustainable Development Goals (
+                                <StyledLink
+                                    href='https://sdgs.un.org/goals'
+                                    title='SDGs'
+                                />
+                                ). In 2020, the COVID-19 pandemic provided a
+                                special impetus to examine these issues through
+                                the survey.
+                            </StyledText>{' '}
+                            <StyledText>
+                                The survey measures attitudes and beliefs about
+                                gender equality, participation in unpaid care
+                                and domestic work, resource allocation, and
+                                COVID-19’s impact on everyday lives. The data
+                                sheds light on differences within countries and
+                                among world regions regarding the extent to
+                                which people agree that men and women should
+                                have equal opportunities. The data also
+                                highlights gender and region-specific challenges
+                                of life during the pandemic, such as food
+                                insecurity, access to education and healthcare,
+                                and employment prospects.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='How the survey contributes to Facebook’s mission and the UN Sustainable Development Goals'>
+                            <StyledText>
+                                This survey is part of{' '}
+                                <StyledLink
+                                    href='https://dataforgood.fb.com/'
+                                    title='Data for Good'
+                                />{' '}
+                                and{' '}
+                                <StyledLink
+                                    href='https://about.fb.com/news/2020/03/closing-the-gender-data-gap/'
+                                    title='Project 17'
+                                />
+                                , two Facebook programs that use data to drive
+                                progress on critical humanitarian issues. Data
+                                for Good provides tools built from
+                                privacy-protected data on Facebook’s platform,
+                                as well as tools developed using satellite
+                                imagery and other publicly available sources.
+                                Similarly, Project 17 emerged from a commitment
+                                Facebook made at the 2019 UN General Assembly to
+                                help partners use data to accelerate progress on
+                                the SDGs.
+                            </StyledText>{' '}
+                            <StyledText>
+                                The Survey on Gender Equality at Home leverages
+                                Facebook’s global reach to fill important
+                                information gaps about gender dynamics in
+                                communities around the world while preserving
+                                users’ privacy from end-to-end. Because the
+                                survey data is disaggregated by men and women
+                                respondents, it can help policymakers,
+                                practitioners, and researchers design and
+                                deliver gender-responsive programs and policies
+                                that support all SDGs.
+                            </StyledText>
+                            <StyledText>
+                                Visit{' '}
+                                <StyledLink
+                                    href='https://dataforgood.fb.com/'
+                                    title='Data for Good'
+                                />
+                                ’s website to learn more about these data
+                                products, read about{' '}
+                                <StyledLink
+                                    href='https://about.fb.com/news/2020/03/closing-the-gender-data-gap/'
+                                    title='Project 17'
+                                />
+                                , and learn{' '}
+                                <StyledLink
+                                    href='https://facebookatunga.com/'
+                                    title='here'
+                                />{' '}
+                                about how Facebook contributes to the SDGs.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Designing the survey'>
+                            <StyledText>
+                                The survey was developed with inputs and
+                                collaboration from the World Bank, UN Women,
+                                Equal Measures 2030, and Ladysmith. Some of the
+                                questions have been borrowed from other surveys
+                                (e.g., face-to-face, telephone surveys, etc.),
+                                allowing for methodological comparisons. As
+                                such, the survey also generates insights useful
+                                to researchers undertaking alternative modes of
+                                data collection during COVID-19. The survey was
+                                also designed to avoid “survey fatigue,” where
+                                respondents begin to disengage from the survey
+                                content and responses become less reliable.
+                                Further details on the methodology are available{' '}
+                                <StyledLink
+                                    href='https://dataforgood.fb.com/wp-content/uploads/2020/09/Survey-on-Gender-Equality-at-Home-Report-1.pdf#page=60'
+                                    title='here'
+                                />
+                                .
+                            </StyledText>{' '}
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Limitations of the data'>
+                            <StyledText>
+                                The survey is limited to respondents who have
+                                Internet access, were active Facebook users
+                                during the fielding of the survey, and opted to
+                                take a survey through the platform. Knowledge of
+                                the overall demographics of the online
+                                population in each country and region allows for
+                                calibration such that estimates are
+                                representative at these levels. However, this
+                                means the results only tell us something about
+                                the online population in each country/region,
+                                not the overall population.
+                            </StyledText>{' '}
+                            <StyledText>
+                                Additionally, estimates have only been generated
+                                for respondents who self-reported their gender
+                                as male or female. The survey included an
+                                “other” option but very few respondents selected
+                                it, making it impossible to generate meaningful
+                                estimates for populations who identify as
+                                non-binary.
+                            </StyledText>{' '}
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Accessing the data'>
+                            <StyledText>
+                                The aggregate regional and country-level
+                                statistics for the Survey on Gender Equality at
+                                Home, which are used to power this dashboard,
+                                can be downloaded on the{' '}
+                                <StyledLink
+                                    href='https://data.humdata.org/organization/facebook'
+                                    title='Humanitarian Data Exchange'
+                                />
+                                .
+                            </StyledText>{' '}
+                            <StyledText>
+                                De-identified, record-level response data to
+                                most questions may be available to individuals
+                                and non-profit organizations for research
+                                purposes. Please email{' '}
+                                <StyledLink
+                                    href='mailto:gendersurvey@fb.com'
+                                    title='gendersurvey@fb.com'
+                                />{' '}
+                                if you are interested in learning more.
+                            </StyledText>{' '}
+                        </StyledAccordionItem>
+                    </Accordion>
+                </ModalBody>
             </ModalContent>
         </Modal>
     );

--- a/src/app/src/components/FaqModal.jsx
+++ b/src/app/src/components/FaqModal.jsx
@@ -5,16 +5,162 @@ import {
     ModalHeader,
     ModalBody,
     ModalCloseButton,
+    Accordion,
 } from '@chakra-ui/react';
+
+import { StyledAccordionItem, StyledLink, StyledText } from './StyledAccordion';
 
 const FaqModal = ({ isOpen, onClose }) => {
     return (
-        <Modal isOpen={isOpen} onClose={onClose}>
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            size='xl'
+            scrollBehavior='inside'
+        >
             <ModalOverlay />
             <ModalContent>
                 <ModalHeader>FAQ</ModalHeader>
                 <ModalCloseButton />
-                <ModalBody>FAQ content</ModalBody>
+                <ModalBody>
+                    <Accordion allowToggle>
+                        <StyledAccordionItem title='How are the country- and region-level statistics calculated?'>
+                            <StyledText>
+                                The country- level statistics provided reflect
+                                the percentage of respondents in each
+                                country/region providing a given response to
+                                each question. These percentages are calculated
+                                based on all people who responded to a given
+                                question (even if their response is "Don't Know"
+                                or "Prefer not to respond"). These percentages
+                                are then calibrated to provide estimates
+                                representing the online population in each
+                                country and then disaggregated for men and
+                                women, shedding light on gender differences
+                                within countries and regions. Weights were
+                                applied at the individual respondent level
+                                before aggregation. Visit the website to learn
+                                more about the methodology (see link above).
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='How should I interpret the values?'>
+                            <StyledText>
+                                Unless otherwise indicated in the Codebook, a
+                                value is the percent of all respondents of that
+                                gender who responded to that specific variable.
+                                For instance, a value of “56” for variable
+                                “a1_neutral” for gender “Female” means that 56%
+                                of all females who answered question A1
+                                responded “neutral.”
+                            </StyledText>
+                            <StyledText>
+                                The codebook indicates exceptions, which are
+                                usually done to enable sharing of data where
+                                individual response counts are too low to
+                                preserve privacy.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title="Why aren't all countries included?">
+                            <StyledText>
+                                The survey was not administered in every country
+                                in the world. (For a list of countries included,{' '}
+                                <StyledLink
+                                    href='https://dataforgood.fb.com/docs/gendersurveyreport/'
+                                    title='visit the website'
+                                />{' '}
+                                to learn more about the methodology).
+                                Additionally, to preserve privacy, responses
+                                from countries where response rates were
+                                insufficient for country-level representation
+                                have been aggregated into a "Rest of region"
+                                group for their geographic region. This dataset
+                                thus includes data for 116 countries across
+                                seven world regions, using the World Bank
+                                classification of countries by region.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Why aren’t statistics provided for every response option for each question?'>
+                            <StyledText>
+                                The country- and region-level estimates are
+                                intended to be consistent with those used to
+                                write the public report (see link above). In
+                                general, the following parameters inform what
+                                data is and is not included: We aimed to cover
+                                as many variables and response categories as
+                                possible within a concise, useful data file.
+                                This necessitated excluding some questions that
+                                are difficult to interpret or are of limited
+                                relevance as country- or region-level aggregate
+                                statistics. For a few of the multiple-choice
+                                questions, we collapse multiple answers
+                                following the same logic used for the public
+                                report. The statistics for some response options
+                                are blank for some countries where an
+                                insufficient number of people responded to
+                                ensure representativeness and anonymity. These
+                                decisions serve to keep a balance between
+                                providing useful data and maintaining a
+                                manageable dataset.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='The survey included an "Optional" section. Where is that data?'>
+                            <StyledText>
+                                In general, respondents were allowed to skip any
+                                question(s) they did not want to answer. Due to
+                                the nature of online surveys and length of the
+                                questionnaire, response rates for this section
+                                were too low to warrant including in this
+                                dataset.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='The survey included open-ended questions. Where are those responses?'>
+                            <StyledText>
+                                Responses to open-ended questions are not
+                                included in this dataset to ensure respondents'
+                                privacy.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Is this data statistically representative of the populations of these countries/regions?'>
+                            <StyledText>
+                                No. Weights were applied to ensure this data is
+                                representative of the online population of the
+                                country/region, but not the total (online and
+                                offline) population. Please be mindful of this
+                                limitation when conducting your analysis. We
+                                have included an estimate of Internet
+                                penetration for each country/region to give
+                                users a sense of the population that responses
+                                from each country represents.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Can I access the raw survey data?'>
+                            <StyledText>
+                                De-identified, record-level response data to
+                                most questions may be available to individuals
+                                and non-profit organizations for research
+                                purposes. Please email{' '}
+                                <StyledLink
+                                    href='mailto:gendersurvey@fb.com'
+                                    title='gendersurvey@fb.com'
+                                />{' '}
+                                if you are interested in learning more.
+                            </StyledText>
+                        </StyledAccordionItem>
+                        <StyledAccordionItem title='Is the data provided for regions and countries the same?'>
+                            <StyledText>
+                                De-identified, record-level response data to
+                                most questions may be available to individuals
+                                and non-profit organizations for research
+                                purposes. Please email{' '}
+                                <StyledLink
+                                    href='mailto:gendersurvey@fb.com'
+                                    title='gendersurvey@fb.com'
+                                />{' '}
+                                if you are interested in learning more.
+                            </StyledText>
+                        </StyledAccordionItem>
+                    </Accordion>
+                </ModalBody>
             </ModalContent>
         </Modal>
     );

--- a/src/app/src/components/StyledAccordion.js
+++ b/src/app/src/components/StyledAccordion.js
@@ -1,0 +1,29 @@
+import {
+    AccordionItem,
+    AccordionButton,
+    AccordionPanel,
+    AccordionIcon,
+    Box,
+    Text,
+    Link,
+} from '@chakra-ui/react';
+
+export const StyledAccordionItem = ({ title, children }) => (
+    <AccordionItem>
+        <AccordionButton>
+            <Box flex='1' textAlign='left' fontWeight={500}>
+                {title}
+            </Box>
+            <AccordionIcon />
+        </AccordionButton>
+        <AccordionPanel p={4}>{children}</AccordionPanel>
+    </AccordionItem>
+);
+
+export const StyledLink = ({ href, title }) => (
+    <Link href={href} textDecoration='underline' isExternal>
+        {title}
+    </Link>
+);
+
+export const StyledText = ({ children }) => <Text p={2}>{children}</Text>;


### PR DESCRIPTION
## Overview

Adds content for the FAQ and About modals. 

Connects #31 

### Demo

<img width="635" alt="Screen Shot 2021-01-13 at 9 27 57 AM" src="https://user-images.githubusercontent.com/21046714/104471191-8e862000-5588-11eb-9dca-74472e41d21a.png">
<img width="619" alt="Screen Shot 2021-01-13 at 9 28 18 AM" src="https://user-images.githubusercontent.com/21046714/104471197-904fe380-5588-11eb-8d0e-45ef8ff34951.png">

### Notes

Ordinarily with a component with this much repetition in structure, if pulling from an API, one would use a mapped list to minimize code. However, in this particular case, the presence of links in the text content adds some complication to this logistically. In addition, since the text is stored locally, we would wouldn't actually be saving many lines of code. In the end, it seemed simplest and clearest to hard-code the sections/content, but use styled components for the repetitious portions of the structure. This allows us to still edit styling of the sections all at once if needed.

## Testing Instructions

 * In the Netlify preview, click the 'FAQ' button. It should open the correct modal. Clicking the accordions should toggle them.
 * Confirm the content matches the [document](https://docs.google.com/document/d/1ygYvYoe9MdTPn_2WkJCLhKUWJE2yiGMXWqmmyKXWLXI/edit#).
 *  Confirm the links work. 
 * Open the About modal and confirm content and links are correct. 
