### PR TITLE
Add Survey Notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow Question Category Select-All/None [#68](https://github.com/azavea/fb-gender-survey-dashboard/pull/68)
 - Download CSVs [#67](https://github.com/azavea/fb-gender-survey-dashboard/pull/67)
 - Add Modal Content [#71](https://github.com/azavea/fb-gender-survey-dashboard/pull/71)
+- Add Survey Notification [#75](https://github.com/azavea/fb-gender-survey-dashboard/pull/75)
 
 ### Changed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -10,6 +10,7 @@ import GeographySelector from './components/GeographySelector';
 import QuestionSelector from './components/QuestionSelector';
 import Visualizations from './components/Visualizations';
 import SavedVisualizations from './components/SavedVisualizations';
+import SurveyNotification from './components/SurveyNotification';
 import NotFound from './components/NotFound';
 import theme from './theme';
 
@@ -38,6 +39,7 @@ function App() {
         <Router>
             <ChakraProvider resetCss theme={theme}>
                 <div className='App'>
+                    <SurveyNotification />
                     <Header />
                     <Switch>
                         <Route exact path={ROUTES.HOME}>

--- a/src/app/src/components/SurveyNotification.js
+++ b/src/app/src/components/SurveyNotification.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+    Alert,
+    AlertIcon,
+    AlertDescription,
+    Box,
+    CloseButton,
+    Link,
+} from '@chakra-ui/react';
+
+import { setSurveyHasBeenDisplayed } from '../redux/survey.actions';
+
+const surveyURL =
+    'https://docs.google.com/forms/d/e/1FAIpQLSfWXehbiAY_7E02FJXDIjbL4dbJSDtQ7DRE_e9uKNeADFmEKw/viewform';
+
+const SurveyNotification = () => {
+    const dispatch = useDispatch();
+    const { surveyHasBeenDisplayed, showSurvey } = useSelector(
+        state => state.survey
+    );
+
+    const markSurveyDisplayed = () => dispatch(setSurveyHasBeenDisplayed(true));
+
+    if (showSurvey && !surveyHasBeenDisplayed) {
+        return (
+            <Box pos='fixed' width='100%' zIndex={1}>
+                <Alert
+                    status='info'
+                    colorScheme='white'
+                    border='1px solid rgb(222, 227, 233)'
+                >
+                    <AlertIcon />
+                    <Box flex='1'>
+                        <AlertDescription display='block' mr='10px'>
+                            You're invited to take a 30-second survey about this
+                            dataset -{' '}
+                            <Link
+                                href={surveyURL}
+                                textDecoration='underline'
+                                isExternal
+                                onClick={markSurveyDisplayed}
+                            >
+                                click here to begin!
+                            </Link>
+                        </AlertDescription>
+                    </Box>
+                    <CloseButton
+                        pos='absolute'
+                        right='8px'
+                        top='8px'
+                        onClick={markSurveyDisplayed}
+                    />
+                </Alert>
+            </Box>
+        );
+    }
+
+    return null;
+};
+
+export default SurveyNotification;

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -21,6 +21,7 @@ import { CONFIG } from '../utils/constants';
 import { DataIndexer } from '../utils';
 import { downloadVisualizationsCSV } from '../utils/csv';
 import { saveVisualization } from '../redux/visualizations.actions';
+import { setShowSurvey } from '../redux/survey.actions';
 import Breadcrumbs from './Breadcrumbs';
 import Chart from './Chart';
 
@@ -35,11 +36,20 @@ const Visualizations = () => {
         geoMode,
         data,
     } = useSelector(state => state.app);
+    const { surveyHasBeenDisplayed, showSurvey } = useSelector(
+        state => state.survey
+    );
 
     // Scroll to top on initial page load
     useEffect(() => {
         window.scrollTo(0, 0);
     }, []);
+
+    useEffect(() => {
+        if (!surveyHasBeenDisplayed && !showSurvey) {
+            setTimeout(() => dispatch(setShowSurvey(true)), 30000);
+        }
+    }, [showSurvey, surveyHasBeenDisplayed, dispatch]);
 
     // If a page reloads directly to this page, restart at home
     if (!currentQuestions.length || !currentGeo.length) {

--- a/src/app/src/redux/reducers.js
+++ b/src/app/src/redux/reducers.js
@@ -2,8 +2,10 @@ import { combineReducers } from 'redux';
 
 import AppReducer from './app.reducer';
 import VisualizationsReducer from './visualizations.reducer';
+import SurveyReducer from './survey.reducer';
 
 export default combineReducers({
     app: AppReducer,
     visualizations: VisualizationsReducer,
+    survey: SurveyReducer,
 });

--- a/src/app/src/redux/store.js
+++ b/src/app/src/redux/store.js
@@ -9,7 +9,7 @@ import reducers from './reducers';
 const persistConfig = {
     key: 'root',
     storage,
-    whitelist: ['visualizations'],
+    whitelist: ['visualizations', 'survey'],
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);

--- a/src/app/src/redux/survey.actions.js
+++ b/src/app/src/redux/survey.actions.js
@@ -1,0 +1,6 @@
+import { createAction } from 'redux-act';
+
+export const setShowSurvey = createAction('Set show survey');
+export const setSurveyHasBeenDisplayed = createAction(
+    'Set survey has been displayed'
+);

--- a/src/app/src/redux/survey.reducer.js
+++ b/src/app/src/redux/survey.reducer.js
@@ -1,0 +1,17 @@
+import { createReducer } from 'redux-act';
+import { set } from '../utils';
+
+import { setShowSurvey, setSurveyHasBeenDisplayed } from './survey.actions';
+
+export const initialState = Object.freeze({
+    showSurvey: false,
+    surveyHasBeenDisplayed: false,
+});
+
+export default createReducer(
+    {
+        [setShowSurvey]: set('showSurvey'),
+        [setSurveyHasBeenDisplayed]: set('surveyHasBeenDisplayed'),
+    },
+    initialState
+);


### PR DESCRIPTION
## Overview

The survey is hidden until 30 seconds after the user has first visited
the visualizations page, at which point the survey notification will
be rendered at the top of the view. The survey notification is set to a
fixed position so that it will be visible on rendering, regardless of
if the user has scrolled down the page, and will appear on any page
which the user is on.

After the initial rendering, the survey will continue to be displayed
until the user has clicked the survey link or has closed it, after which
the survey will not appear again.

The survey status is stored in a persisted reducer to be consistent
with how we have managed other local storage data.

Connects #69 

### Demo

<img width="1224" alt="Screen Shot 2021-01-21 at 11 27 35 AM" src="https://user-images.githubusercontent.com/21046714/105384304-0b944380-5be0-11eb-9002-7d5cd8253b57.png">

## Testing Instructions

 * Navigate to the Visualizations page in the Nelify preview. The survey notification shouldn't show. 
 * Wait for 30 seconds (scrolling or navigating around the application while you wait is fine).
 * The survey notification should appear. Click the link. 
 * You should be taken to the survey in a new tab. The notification should disappear in the Netlify preview. 
 * Refresh the page, navigate to the visualizations page, and wait for 30 seconds. The notification shouldn't appear. 
 * Clear out local storage, refresh, navigate to the visualizations page, and wait for 30 seconds. 
 * Once the notification appears, click the 'close' button. The notification should disappear. 
 * Refresh the page, navigate to the visualizations page, and wait for 30 seconds. The notification shouldn't appear. 
