### PR TITLE
Adjust Grouped Bar Height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle Percentage Charts [#58](https://github.com/azavea/fb-gender-survey-dashboard/pull/58)
 - Update Text Copy and Header [#70](https://github.com/azavea/fb-gender-survey-dashboard/pull/70)
+- Adjust Grouped Bar Height [#77](https://github.com/azavea/fb-gender-survey-dashboard/pull/77)
 
 ### Fixed
 

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -25,10 +25,11 @@ const GroupedBarChart = ({ items }) => {
 
     const containerRef = useRef();
 
+    const height = 150 + data.length * 50;
+
     return (
         <Box
             className='chart-container'
-            h={250}
             ref={containerRef}
             border='1px solid'
             borderColor='gray.100'
@@ -36,6 +37,7 @@ const GroupedBarChart = ({ items }) => {
             bg='white'
             borderRadius='md'
             m={4}
+            height={height}
         >
             <DownloadMenu
                 chartContainerRef={containerRef}


### PR DESCRIPTION
## Overview

Adjusts the height of the grouped bar chart based on the number of
items in order to prevent items from shrinking to an unreadable level
when large numbers of items are present.

Connects #74 

### Demo

One Item
<img width="943" alt="Screen Shot 2021-01-22 at 2 30 59 PM" src="https://user-images.githubusercontent.com/21046714/105537063-5afd7100-5cbf-11eb-980d-f0001c2638bd.png">

Many Items
<img width="934" alt="Screen Shot 2021-01-22 at 2 31 36 PM" src="https://user-images.githubusercontent.com/21046714/105537074-5cc73480-5cbf-11eb-9ffd-b9b349f48761.png">

## Testing Instructions

 * In the Netlify preview, select one country and a grouped chart question. The chart should render to a reasonable height. 
 * Select many countries and a grouped chart question. The chart should render to a reasonable height.
