### PR TITLE
Update Chart Colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Text Copy and Header [#70](https://github.com/azavea/fb-gender-survey-dashboard/pull/70)
 - Adjust Grouped Bar Height [#77](https://github.com/azavea/fb-gender-survey-dashboard/pull/77)
 - Small Features [#79](https://github.com/azavea/fb-gender-survey-dashboard/pull/79)
+- Update Chart Colors [#81](https://github.com/azavea/fb-gender-survey-dashboard/pull/81)
 
 ### Fixed
 

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -90,7 +90,20 @@ const GroupedBarChart = ({ items }) => {
                 maxValue={isPercent ? 100 : 'auto'}
                 groupMode='grouped'
                 layout='horizontal'
-                colors={{ scheme: 'set1' }}
+                colors={item => {
+                    if (item.id === 'Women') {
+                        return 'rgb(54, 17, 52)';
+                    } else if (item.id === 'Men') {
+                        return 'rgb(220, 56, 70)';
+                    } else if (item.id === 'Total') {
+                        return 'rgb(243, 164, 142)';
+                    } else {
+                        console.warning(
+                            'An unexpected item was passed to the chart.'
+                        );
+                        return 'rgb(198, 198, 198)';
+                    }
+                }}
                 axisTop={{
                     tickSize: 0,
                     tickPadding: 5,

--- a/src/app/src/components/StackedBarChart.js
+++ b/src/app/src/components/StackedBarChart.js
@@ -54,7 +54,20 @@ const StackedBarChart = ({ items }) => {
                     maxValue={100}
                     groupMode='stacked'
                     layout='horizontal'
-                    colors={{ scheme: 'dark2' }}
+                    colors={item => {
+                        if (item.id === 'Strongly Disagree/Disagree') {
+                            return 'rgb(54, 17, 52)';
+                        } else if (item.id === 'Neutral') {
+                            return 'rgb(243, 164, 142)';
+                        } else if (item.id === 'Strongly Agree/Agree') {
+                            return 'rgb(220, 56, 70)';
+                        } else {
+                            console.warning(
+                                'An unexpected item was passed to the chart.'
+                            );
+                            return 'rgb(198, 198, 198)';
+                        }
+                    }}
                     axisTop={{
                         tickSize: 0,
                         tickPadding: 5,

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -62,6 +62,20 @@ const WaffleChart = ({ items }) => {
                                 data={data}
                                 key={`waffle-${question.qcode}${response.geo}${data[0].label}`}
                                 pixelRatio={2}
+                                colors={item => {
+                                    if (item.label === 'Women') {
+                                        return 'rgb(54, 17, 52)';
+                                    } else if (item.label === 'Men') {
+                                        return 'rgb(220, 56, 70)';
+                                    } else if (item.label === 'Total') {
+                                        return 'rgb(243, 164, 142)';
+                                    } else {
+                                        console.warning(
+                                            'An unexpected item was passed to the chart.'
+                                        );
+                                        return 'rgb(198, 198, 198)';
+                                    }
+                                }}
                                 total={10}
                                 rows={2}
                                 columns={5}


### PR DESCRIPTION
## Overview

Final confirmed colors for charts match the current mockups for Grouped
and Waffle charts, specifically:
- Women: rgb(54, 17, 52) (Dark Red)
- Men: rgb(220, 56, 70) (Red)
- Total: rgb(243, 164, 142) (Pink)

Final confirmed colors for Stacked charts were requested to use the
same colors as for the Grouped and Waffle charts (differing from current
designs), specifically:
- Disagree: rgb(54, 17, 52) (Dark Red)
- Neutral: rgb(243, 164, 142) (Pink)
- Agree: rgb(220, 56, 70) (Red)

Connects #65 

### Demo

<img width="1019" alt="Screen Shot 2021-01-25 at 2 45 41 PM" src="https://user-images.githubusercontent.com/21046714/105757912-a3659a80-5f1c-11eb-8282-5e3482e6f1c6.png">
<img width="991" alt="Screen Shot 2021-01-25 at 2 45 52 PM" src="https://user-images.githubusercontent.com/21046714/105757917-a496c780-5f1c-11eb-9708-1ae026c25cf5.png">
<img width="983" alt="Screen Shot 2021-01-25 at 2 45 58 PM" src="https://user-images.githubusercontent.com/21046714/105757922-a6608b00-5f1c-11eb-9cd0-386a74932440.png">

### Notes

The colors for the bar charts are reversed from the designs because of the way horizontal charts are flipped by Nivo. With the current code for Nivo, we can't reverse these without also reversing the order of the items in the legend/key for each chart. For stacked charts, it might be reasonable to do this if we want 'disagree' on the left for certain; but for grouped charts, it seems like it wouldn't make sense to put 'Total' as the last item in the legend list. Thoughts welcomed on this point. 

## Testing Instructions

 * In the Netlify preview, select a region and then one of each type of question/chart. Confirm that colors for all charts match the requested colors. 
