### PR TITLE
Open Categories in Response to Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Open Categories in Response to Search [#82](https://github.com/azavea/fb-gender-survey-dashboard/pull/82)
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
## Overview

When the user enters a search term on the questions page, categories
are automatically opened if they contain matching questions, and closed
if they have no matching questions. Note that this means that if the
user has manually opened or closed a category, then enters or changes a
search, the expansion of the accordion will be changed, as there isn't
a reasonable way to track which categories have been manually toggled
by the user.

Connects #73 

### Demo

![Search](https://user-images.githubusercontent.com/21046714/105904109-bba5ea00-5fee-11eb-859f-9f5fc6dba773.gif)

## Testing Instructions

 * In the Netlify preview, select a geography and move to the questions page. Enter a search - categories with matching items should open. 
 * Type a search that will not match any questions - the categories should close. 
 * Select some questions, go to the charts page, and return. Selected categories should open by default on page load as before. 
