### PR TITLE
Fix Question Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Question Filtering [#91](https://github.com/azavea/fb-gender-survey-dashboard/pull/91)
+
 ### Removed
 
 ## 1.1.0

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -66,14 +66,26 @@ const QuestionSelector = () => {
 
             const filteredQuestionCodes = query.trim().length
                 ? questionCodes.filter(q => {
+                      if (currentQuestions.includes(q)) return true;
+
                       const item = config.survey[q];
-                      return (
-                          currentQuestions.includes(q) ||
-                          (item &&
+
+                      // if the item isn't found,
+                      // we need to look at items that match the qcode
+                      if (!item) {
+                          const items = Object.keys(config.survey)
+                              .map(key => config.survey[key])
+                              .filter(question => question.qcode === q);
+                          return items.some(question =>
                               formatQuery(
-                                  `${item.question} ${item.cat}`
-                              ).includes(formatQuery(query)))
-                      );
+                                  `${question.question} ${question.cat}`
+                              ).includes(formatQuery(query))
+                          );
+                      } else {
+                          return formatQuery(
+                              `${item.question} ${item.cat}`
+                          ).includes(formatQuery(query));
+                      }
                   })
                 : questionCodes;
             return { cat, catCode, questionCodes, filteredQuestionCodes };


### PR DESCRIPTION
## Overview

StackedChart items ('agree or disagree') weren't being matched by the
question search, because for these items multiple survey responses are
nested under one question code. We therefore need to compare the
query to multiple responses for these questions, using the question code
 instead of the response code.

Connects #78 

### Demo

<img width="1262" alt="Screen Shot 2021-02-02 at 11 38 16 AM" src="https://user-images.githubusercontent.com/21046714/106632558-e393d100-654b-11eb-9465-bdc96954111c.png">

## Testing Instructions

 * On [staging](https://develop--gender-survey-dashboard.netlify.app/visualization), select some countries and click 'next'.
 * Enter 'expense' into the search bar - you will see three questions found. 
 * In the Netlify preview for this PR, select some countries and click 'next'. (You can find the Netlify preview link near the merge button below - where it says, 'deploy/netlify' click the 'details' link). 
 * Enter 'expense' into the search bar - you will see four questions found.  
 * Select any item and enter a new search that doesn't match that item. The selected item should remain visible, and appropriate items should be found matching your query. 