### PR TITLE
Add Titles to Chart Downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Titles to Chart Downloads [#95](https://github.com/azavea/fb-gender-survey-dashboard/pull/95)
+
 ### Changed
 
 - Recognize Gender as Percent and Update Data [#93](https://github.com/azavea/fb-gender-survey-dashboard/pull/93)

--- a/src/app/src/components/DownloadMenu.jsx
+++ b/src/app/src/components/DownloadMenu.jsx
@@ -9,7 +9,7 @@ import {
     MenuItem,
 } from '@chakra-ui/react';
 import { FaDownload } from 'react-icons/fa';
-import { combineCanvases, setBackgroundColor } from '../utils/canvas';
+import { combineCanvases, setBackgroundColor, addTitle } from '../utils/canvas';
 import { downloadCSV } from '../utils/csv';
 
 const download = (dataUrl, filename, filetype = 'png') => {
@@ -51,8 +51,14 @@ const DownloadMenu = ({
                 ? combineCanvases(chartCanvases, combineDir)
                 : chartCanvases[0];
 
+        const title = `Question ${question.qcode}${
+            question.type === 'ten' ? ` in ${question.geo}` : ''
+        }: ${question.question}`;
+
+        const canvasWithTitle = addTitle(chartCanvas, title);
+
         // Set a white background instead of the default transparent
-        const newCanvas = setBackgroundColor(chartCanvas, '#FFF');
+        const newCanvas = setBackgroundColor(canvasWithTitle, '#FFF');
 
         // Convert the entire new canvas to a base64 data URL
         const dataUrl = newCanvas.toDataURL('image/png');

--- a/src/app/src/components/SearchInput.js
+++ b/src/app/src/components/SearchInput.js
@@ -12,7 +12,12 @@ import { IoIosSearch } from 'react-icons/io';
 
 const SearchInput = ({ query, setQuery, placeholder }) => {
     return (
-        <FormControl role='search' as='form' flex={1}>
+        <FormControl
+            role='search'
+            as='form'
+            flex={1}
+            onSubmit={e => e.preventDefault()}
+        >
             <FormLabel>
                 <VisuallyHidden>Search</VisuallyHidden>
             </FormLabel>

--- a/src/app/src/utils/canvas.js
+++ b/src/app/src/utils/canvas.js
@@ -6,12 +6,85 @@ export const combineCanvases = (canvasList, direction) => {
     }
 };
 
+function generateWrappedText(context, text, width, font) {
+    context.font = font;
+
+    // distance from left
+    const x = 20;
+    // distance from top; this will change for each line
+    let y = 50;
+    // max width of text is width of container minus twice the desired padding
+    const maxWidth = width - x * 2;
+    // line height for text is 1.2 * text size
+    const lineHeight = 50;
+
+    const words = text.split(' ');
+    let line = '';
+    const lines = [];
+    words.forEach((word, i) => {
+        let testLine = line + word + ' ';
+        let metrics = context.measureText(testLine);
+        let testWidth = metrics.width;
+        if (testWidth > maxWidth && i > 0) {
+            lines.push({ line, x, y });
+            line = word + ' ';
+            y += lineHeight;
+        } else {
+            line = testLine;
+        }
+    });
+
+    lines.push({ line, x, y });
+    return { textHeight: y + lineHeight, lines };
+}
+
+function wrapText(context, lines, font) {
+    context.font = font;
+    context.fillStyle = '#000';
+
+    lines.forEach(item => {
+        const { line, x, y } = item;
+        context.fillText(line, x, y);
+    });
+
+    return context;
+}
+
+export const addTitle = (canvas, title) => {
+    const chartCanvas = document.createElement('canvas');
+    chartCanvas.width = canvas.width;
+    chartCanvas.height = canvas.height;
+
+    const newCtx = chartCanvas.getContext('2d');
+
+    const font = '40px sans-serif';
+
+    const { textHeight, lines } = generateWrappedText(
+        newCtx,
+        title,
+        chartCanvas.width,
+        font
+    );
+
+    chartCanvas.height = canvas.height + textHeight;
+
+    newCtx.fillStyle = '#fff';
+    newCtx.fillRect(0, 0, chartCanvas.width, chartCanvas.height);
+
+    wrapText(newCtx, lines, font);
+
+    newCtx.drawImage(canvas, 0, textHeight);
+
+    return chartCanvas;
+};
+
 export const combineHorizontal = canvasList => {
     const chartCanvas = document.createElement('canvas');
     chartCanvas.width = canvasList[0].width * canvasList.length;
     chartCanvas.height = canvasList[0].height;
 
     const newCtx = chartCanvas.getContext('2d');
+
     canvasList.forEach((c, i) => {
         newCtx.drawImage(c, 0 + c.width * i, 0);
     });
@@ -26,6 +99,7 @@ export const setBackgroundColor = (canvas, color) => {
     const ctx = newCanvas.getContext('2d');
     ctx.fillStyle = color;
     ctx.fillRect(0, 0, newCanvas.width, newCanvas.height);
+
     ctx.drawImage(canvas, 0, 0);
 
     return newCanvas;


### PR DESCRIPTION
## Overview

Adds the survey questions, answers, and codes as titles to the chart
downloads. For waffle charts, include the geography as part of the title.

Recent updates to the query input caused it to refresh the page on submission. 
Fixes that by preventing submission.

Connects #27 and #96

### Demo
Stacked Chart:
![A 1_Armenia_How much do you agree or disagree with the following statement_ “Men and women should have equal opportunities (e g  in education, jobs, household decision-making)](https://user-images.githubusercontent.com/21046714/106811420-4cf30d00-663c-11eb-92fb-07a0ebcfff41.png)
Waffle Chart:
![A 2_Armenia_Out of 10 of your neighbors, how many do you think believe that men and women should have equal opportunities (e g  in education, jobs, household decision-making) _](https://user-images.githubusercontent.com/21046714/106811446-554b4800-663c-11eb-9b8f-0527d943e528.png)
Grouped Chart:
![A 3_Yes_Last week, did you do any work for pay, do any kind of business, farming or other activity to generate income, even if only for one hour_](https://user-images.githubusercontent.com/21046714/106811454-57150b80-663c-11eb-8ee5-52b9e1f0d1b4.png)

## Testing Instructions

 * In the Netlify preview, select some number of locations
 * On the questions page, select several questions, at least one of each type ('agree or disagree', 'out of ten', and ones with 'Answered')
 * On the charts page, hover over a chart to see the download button. Click it, and in the menu select 'png'
 * A chart should download. Open it and confirm that it has the question code and question, the answer where applicable, and the location if it is a waffle chart, as a title.
 * Repeat with each type of chart. 
 * On the question page, search and press enter. The page should not refresh. 
