### PR TITLE
Add License Information to About

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added License Information to About [#98](https://github.com/azavea/fb-gender-survey-dashboard/pull/98)
+
 ### Fixed
 
 ### Removed

--- a/src/app/src/components/AboutModal.jsx
+++ b/src/app/src/components/AboutModal.jsx
@@ -210,6 +210,17 @@ const AboutModal = ({ isOpen, onClose }) => {
                                 if you are interested in learning more.
                             </StyledText>{' '}
                         </StyledAccordionItem>
+                        <StyledAccordionItem title='Source code'>
+                            <StyledText>
+                                The source code for this website is available
+                                under an Apache license. The code is available{' '}
+                                <StyledLink
+                                    href='https://github.com/azavea/fb-gender-survey-dashboard'
+                                    title='here'
+                                />
+                                .
+                            </StyledText>
+                        </StyledAccordionItem>
                     </Accordion>
                 </ModalBody>
             </ModalContent>


### PR DESCRIPTION
## Overview

Adds a link to the source code and license information to the About
modal.

### Demo

<img width="698" alt="Screen Shot 2021-02-05 at 10 43 27 AM" src="https://user-images.githubusercontent.com/21046714/107055477-5779e780-679f-11eb-87f9-6d12f2919cd9.png">

## Testing Instructions

 * In the Netlify preview, open the 'about' modal. Confirm that there is a new accordion item called 'Source code' that contains a link to the source code. 
