### PR TITLE
Force Netlify Build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,4 @@
   base    = "src/app"
   publish = "build"
   command = "../../scripts/cibuild"
+  ignore = "false"


### PR DESCRIPTION
## Overview

Netlify isn't able to recognize the submodule changes to the data.
It's therefore cancelling the build on master and preventing a
deployment. This updates the Netlify build settings to deploy the app
when the `master` branch is updated, even if there are no visible
changes.
