### PR TITLE
Update get-pip url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update get-pip url [#109](https://github.com/azavea/fb-gender-survey-dashboard/pull/109)
+
 ### Removed
 
 # 1.4.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(2) do |config|
   end
 
   # React
-  config.vm.network :forwarded_port, guest: 3333, host: 3333 
+  config.vm.network :forwarded_port, guest: 3333, host: 3333
 
   # Change working directory to /vagrant upon session start.
   config.vm.provision "shell", inline: <<SCRIPT
@@ -24,12 +24,15 @@ Vagrant.configure(2) do |config|
       echo "cd /vagrant" >> "/home/vagrant/.bashrc"
     fi
 
+    sudo apt-get install -qq -y python3-distutils
+
 SCRIPT
 
   config.vm.provision "ansible_local" do |ansible|
     ansible.compatibility_mode = "2.0"
     ansible.install_mode = "pip_args_only"
     ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3" }
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python3"
     ansible.pip_args = "ansible==#{ANSIBLE_VERSION}"
     ansible.playbook = "deployment/ansible/fb-gender-survey.yml"
     ansible.galaxy_role_file = "deployment/ansible/roles.yml"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,6 +1,6 @@
 ---
 pip_executable: "pip3"
-pip_version: "20.2.*"
+pip_version: "20.3.*"
 
 docker_version: "5:19.*"
 docker_compose_version: "1.26.*"


### PR DESCRIPTION
## Overview

The setup script is failing due to a pip error following the url for get-pip changing. We have seen this on several other projects, and it has been repaired by specifying the correct URL in the Vagrant file.

Connects #106 

## Testing Instructions

 * Run `./scripts/setup` and confirm that the build succeeds. 
 * In Vagrant, run `./scripts/update` and `./scripts/server`. The app should load and run correctly at http://localhost:3333. 
