### PR TITLE
Use local data for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-# Data processing output
+# Data processing
+src/dataproc/*.xlsx
 src/dataproc/output/*
 
 # Ansible
@@ -17,6 +18,7 @@ vendor.bundle.js
 bundle.js.map
 dist/
 yarn-error.log
+src/app/.eslintcache
 
 # macOS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enable cross-origin requests [#111](https://github.com/azavea/fb-gender-survey-dashboard/pull/111)
+- Use local data for development [#110](https://github.com/azavea/fb-gender-survey-dashboard/pull/110)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Facebook's data team:
 <https://data.humdata.org/dataset/survey-on-gender-equality-at-home>
 
 To convert the source dataset into a format used by the application, run the
-`dataproc` script on your VM.
+`dataproc` script on your VM. irst, you will need to download the two Excel
+sheets from GDrive and place in `src/dataproc`. In the future, this script will
+automatically download the required data from HDX.
 
 ```sh
 vagrant up

--- a/src/dataproc/generate_data.py
+++ b/src/dataproc/generate_data.py
@@ -11,6 +11,10 @@ region_xls_uri = "https://data.humdata.org/dataset/504fce69-12c2-4c56-ada2-3173c
 
 output_dir = "/opt/src/src/dataproc/output"
 
+# Currently, these path are local to the dataproc contatiner but are intended
+# to be replaced by the appropriate URI, as defined above.
+region_xls_uri = "/opt/src/src/dataproc/sog_agg_region.xlsx"
+country_xls_uri = "/opt/src/src/dataproc/sog_agg_country.xlsx"
 
 class NpEncoder(json.JSONEncoder):
     """Numpy type encoder.


### PR DESCRIPTION
## Overview

Until the 2021 data is live on HDX, we will need to use local data
for development. Updates the URIs for the data to point to local copies
of the data files.

Connects #107 

### Notes

This partially undoes the work done in [issue 53](https://github.com/azavea/fb-gender-survey-dashboard/pull/53). 

This update should have resulted in no changes to the data as of yet, because we are still using the 2020 data set, albeit locally. 

## Testing Instructions

 * Download the two Excel sheets (sog_agg_region and sog_agg_country) from the Gender Equality Google Drive. 
 * Follow the directions in the Readme under `Data` and `Updating application with new data`. 
 * Run `./scripts/server`.
 * Confirm that the app functions as before. 
