### PR TITLE
Enable Cross-Origin Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enable cross-origin requests [#111](https://github.com/azavea/fb-gender-survey-dashboard/pull/111)
+
 ### Fixed
 
 - Update get-pip url [#109](https://github.com/azavea/fb-gender-survey-dashboard/pull/109)

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,8 @@
   publish = "build"
   command = "../../scripts/cibuild"
   ignore = "false"
+
+[[headers]]
+for = "/*"
+  [headers.values]
+  Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
## Overview

Updates Equality at Home to allow cross-origin requests to support
embedding the Equality at Home site within the Data for Good page.

Connects #108 

## Demo

<img width="1041" alt="Screen Shot 2021-08-24 at 11 06 12 AM" src="https://user-images.githubusercontent.com/21046714/130641510-44823a2d-e905-412b-bc95-be4c6df0dc8c.png">

## Testing Instructions

 * Confirm the app can be embedded by viewing it this deploy preview in an iframe in [a test page](https://taiwilkin.github.io/test-iframe/).
