### PR TITLE
Hide unavailable questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Process 2021 config data [#120](https://github.com/azavea/fb-gender-survey-dashboard/pull/120)
 - Add 2021 data [#121](https://github.com/azavea/fb-gender-survey-dashboard/pull/121)
+- Hide unavailable questions [#122](https://github.com/azavea/fb-gender-survey-dashboard/pull/122)
 
 ### Changed
 

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -370,6 +370,10 @@ const QuestionSelector = () => {
                 maxW='1200px'
             >
                 <Text size='2xl' fontWeight='bold'>
+                    Showing charts for: {currentYears.join(',')}
+                    <Box as='span' opacity='0.5' mx={1}>
+                        •
+                    </Box>
                     {currentGeo.join(', ')}
                 </Text>
             </Flex>

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -173,7 +173,11 @@ const Visualizations = () => {
                 maxW='1200px'
             >
                 <Text size='2xl' fontWeight='bold'>
-                    Showing charts for: {currentGeo.join(', ')}
+                    Showing charts for: {currentYears.join(', ')}
+                    <Box as='span' opacity='0.5' mx={1}>
+                        •
+                    </Box>
+                    {currentGeo.join(', ')}
                     <Box as='span' opacity='0.5' mx={1}>
                         •
                     </Box>

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -18,6 +18,8 @@ export const isQuestionCode = key => {
     return key.includes('.');
 };
 
+const isCellEmpty = value => value == null || value.length === 0;
+
 export class DataIndexer {
     constructor(years, geoMode, geographies, data) {
         // Index the data by the current year and geography mode
@@ -57,9 +59,11 @@ export class DataIndexer {
 
     formatForViz(key, geo) {
         const resp = this.survey[key];
+
         if (!resp) {
-            return { key, geo };
+            return { key, geo, dataUnavailable: true };
         }
+
         const idx = resp.idx;
         const d = this.data.geographies[geo];
         const c = this.formatCell(d, 'Combined', idx);
@@ -67,6 +71,7 @@ export class DataIndexer {
         const f = this.formatCell(d, 'Female', idx);
 
         const dataUnavailable = c == null && m == null && f == null;
+
         return {
             key: key,
             geo: geo,
@@ -80,7 +85,7 @@ export class DataIndexer {
 
     formatCell(d, g, idx) {
         const cell = d[g][idx];
-        return cell === null ? null : cell.toFixed(2);
+        return isCellEmpty(cell) ? null : cell.toFixed(2);
     }
 
     getAllResponsesForQ(qcode) {
@@ -96,6 +101,14 @@ export class DataIndexer {
         // attribute is the only thing that makes a general question a response
         const { cat, ...rest } = response;
         return rest;
+    }
+
+    isDataUnavailable(key) {
+        // There is no data available for the question
+        // for any selected geography in the current year
+        return this.geographies.every(
+            geo => this.formatForViz(key, geo).dataUnavailable
+        );
     }
 }
 


### PR DESCRIPTION
## Overview

While some questions were asked in both years, some questions were only
asked in 2020 or 2021. After users select a year, they should only see
questions which are applicable in the currently selected year.

Also adds the selected year(s) to the displayed information at the top of each page.

Connects #113 

### Demo

<img width="1237" alt="2020" src="https://user-images.githubusercontent.com/21046714/139670013-8f355541-b157-4e80-aa7d-dfe51392246e.png">
<img width="1233" alt="2021" src="https://user-images.githubusercontent.com/21046714/139670025-e8ac8978-e174-429c-b3ca-b6561d916e48.png">

## Testing Instructions

 * This is a fully frontend issue, so it can be tested in the Netlify preview. 
 * Select several countries or regions and the year 2020.
 *  Navigate to the questions page. Note the number of questions that are available in each category. 
 * Select questions using the both the individual questions checkboxes and the category checkboxes. 
 * View the charts page and confirm the selected questions are displayed. 
 * Return to the years page and select 2021. 
 * Navigate to the questions page. Note the number of questions that are available in each category, and that they are different from the number of questions available in 2020.
 * Repeat the question selection and testing as you did for 2020.
