### PR TITLE
Show year in charts and downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable cross-origin requests [#111](https://github.com/azavea/fb-gender-survey-dashboard/pull/111)
 - Use local data for development [#110](https://github.com/azavea/fb-gender-survey-dashboard/pull/110)
 - Add year selector [#116](https://github.com/azavea/fb-gender-survey-dashboard/pull/116)
+- Add year in charts and downloads [#124](https://github.com/azavea/fb-gender-survey-dashboard/pull/124)
 
 ### Fixed
 

--- a/src/app/src/components/DownloadMenu.jsx
+++ b/src/app/src/components/DownloadMenu.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { useSelector } from 'react-redux';
 import {
     Flex,
     IconButton,
@@ -21,12 +21,12 @@ const download = (dataUrl, filename, filetype = 'png') => {
     dl.remove();
 };
 
-const createFilename = questionAttrs => {
+const createFilename = (questionAttrs, years) => {
     // Assemble a file name from question components
     const { cat, geo, qcode, question } = questionAttrs;
     const catDisplay = cat ? `${cat}_` : '';
     const geoDisplay = geo ? `${geo}_` : '';
-    return `${qcode}_${geoDisplay}${catDisplay}${question}`;
+    return `${years.join('_')}_${qcode}_${geoDisplay}${catDisplay}${question}`;
 };
 
 const DownloadMenu = ({
@@ -35,6 +35,7 @@ const DownloadMenu = ({
     combineDir = 'horizontal',
     csvData,
 }) => {
+    const { currentYears } = useSelector(state => state.app);
     const saveImage = () => {
         // Use the ref for the chart container to find the canvas DOM element,
         // which is the chart itself
@@ -42,7 +43,7 @@ const DownloadMenu = ({
             'canvas'
         );
 
-        const filename = createFilename(question);
+        const filename = createFilename(question, currentYears);
 
         // Depending on the chart type, there may be many canvas elements.
         // Coerce them into a single canvas, or if just one, use it directly.
@@ -52,7 +53,9 @@ const DownloadMenu = ({
                 : chartCanvases[0];
 
         const title = `Question ${question.qcode}${
-            question.type === 'ten' ? ` in ${question.geo}` : ''
+            question.type === 'ten'
+                ? ` in ${question.geo} in ${question.year}`
+                : ''
         }: ${question.question}`;
 
         const canvasWithTitle = addTitle(chartCanvas, title);

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -9,11 +9,13 @@ const GroupedBarChart = ({ items }) => {
     const data = items
         .map(({ response }) => ({
             ...response,
+            geoyear: `${response.geo} ${response.year}`,
             Men: response.male,
             Women: response.female,
             Total: response.combined,
         }))
         .reverse();
+
     const keys = ['Total', 'Men', 'Women'];
 
     const { cat, qcode, type } = items[0].question;
@@ -75,12 +77,12 @@ const GroupedBarChart = ({ items }) => {
             <ResponsiveBarCanvas
                 data={data}
                 keys={keys}
-                indexBy='geo'
+                indexBy='geoyear'
                 margin={{
                     top: 50,
                     right: 110,
                     bottom: isPercent ? 60 : 50,
-                    left: 220,
+                    left: 230,
                 }}
                 pixelRatio={2}
                 padding={0.15}

--- a/src/app/src/components/StackedBarChart.js
+++ b/src/app/src/components/StackedBarChart.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Box } from '@chakra-ui/react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
 
@@ -7,18 +8,28 @@ import useRefs from '../hooks/useRefs';
 import { formatStackedCSV } from '../utils/csv';
 
 const StackedBarChart = ({ items }) => {
+    const { currentYears } = useSelector(state => state.app);
     const containerRefs = useRefs(items.length);
-
     return items.map(({ question, responses }, i) => {
-        const data = responses.reduce(
-            (acc, curr) => {
-                acc[0][curr.cat] = Math.round(curr.combined, 2);
-                acc[1][curr.cat] = Math.round(curr.male, 2);
-                acc[2][curr.cat] = Math.round(curr.female, 2);
-                return acc;
-            },
-            [{ index: 'Total' }, { index: 'Men' }, { index: 'Women' }]
-        );
+        const data = currentYears
+            .map(year =>
+                responses
+                    .filter(r => r.year === year)
+                    .reduce(
+                        (acc, curr) => {
+                            acc[0][curr.cat] = Math.round(curr.combined, 2);
+                            acc[1][curr.cat] = Math.round(curr.male, 2);
+                            acc[2][curr.cat] = Math.round(curr.female, 2);
+                            return acc;
+                        },
+                        [
+                            { index: `Total ${year}` },
+                            { index: `Men ${year}` },
+                            { index: `Women ${year}` },
+                        ]
+                    )
+            )
+            .flat();
         const keys = responses.map(r => r.cat);
         const formatValue = v => `${v}%`;
 
@@ -45,7 +56,7 @@ const StackedBarChart = ({ items }) => {
                     data={data}
                     keys={keys}
                     indexBy='index'
-                    margin={{ top: 50, right: 250, bottom: 60, left: 80 }}
+                    margin={{ top: 50, right: 250, bottom: 60, left: 120 }}
                     pixelRatio={2}
                     padding={0.25}
                     innerPadding={0}

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -37,7 +37,7 @@ const WaffleChart = ({ items }) => {
             <Box py={4} key={`waffle-${question.qcode}${response.geo}`}>
                 <Flex justify='center' mb={2}>
                     <Text as='strong' size='sm'>
-                        {response.geo}
+                        {response.geo} {response.year}
                     </Text>
                 </Flex>
                 <Box
@@ -53,7 +53,11 @@ const WaffleChart = ({ items }) => {
                 >
                     <DownloadMenu
                         chartContainerRef={containerRefs.current[i]}
-                        question={{ ...question, geo: response.geo }}
+                        question={{
+                            ...question,
+                            geo: response.geo,
+                            year: response.year,
+                        }}
                         csvData={formatWaffleCSV({ question, response })}
                     />
                     <HStack

--- a/src/app/src/utils/csv.js
+++ b/src/app/src/utils/csv.js
@@ -1,5 +1,6 @@
 const csvHeader = [
     'Geography',
+    'Year',
     'Question Code',
     'Question Text',
     'Response Category',
@@ -12,6 +13,7 @@ const addCSVResponse = ({ question, response, data }) => {
     // This order must match the header columns
     const row = [
         response.geo,
+        response.year,
         question.qcode,
         question.question,
         response.cat,

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -24,6 +24,7 @@ export class DataIndexer {
     constructor(years, geoMode, geographies, data) {
         // Index the data by the current year and geography mode
         // TODO: Enable multi-year question handling
+        this.year = years[0];
         this.data = data[geoMode][years[0]];
         this.geographies = geographies;
         this.survey = CONFIG[geoMode].survey;
@@ -59,7 +60,6 @@ export class DataIndexer {
 
     formatForViz(key, geo) {
         const resp = this.survey[key];
-
         if (!resp) {
             return { key, geo, dataUnavailable: true };
         }
@@ -79,6 +79,7 @@ export class DataIndexer {
             combined: c,
             female: f,
             male: m,
+            year: this.year,
             dataUnavailable,
         };
     }


### PR DESCRIPTION
## Overview

Now that multiple years are available, users should be able to see in
their downloads which year is being displayed in PNGs and CSVs.

Adds the year to each response row in the CSV downloads.

Adds the year to the question / title of the waffle chart, which will only ever
display one year. Adds the year beside each bar in the bar charts (which
will show multiple years in comparison view).

Connects #117 

### Demo

![A 2_Egypt_Out of 10 of your neighbors, how many do you think believe that girls and boys should share household tasks equally_ Please enter a whole number between 0 and 10](https://user-images.githubusercontent.com/21046714/140170512-143a6ec9-56dd-474b-a5a0-29c4d130b8a7.png)
![A 14_Egypt_How much do you agree or disagree with the following statement_ “Boys and girls should share household tasks equally”_ Select one](https://user-images.githubusercontent.com/21046714/140173070-1edbb42b-a5e7-4fb4-bddb-9ed80fb219db.png)
![C 6_Education_What area of your life has been most impacted by the Coronavirus pandemic (COVID-19)_ Select all that apply (3)](https://user-images.githubusercontent.com/21046714/140173305-69e80354-d851-4718-9f07-0ac5653265ee.png)

<img width="594" alt="Screen Shot 2021-11-03 at 2 26 03 PM" src="https://user-images.githubusercontent.com/21046714/140170534-55a036fb-f529-46f0-8bed-83dce6d62dee.png">

## Notes

For the bar charts, which will be reused for comparative view, I have followed the mockup in [the SOW](https://drive.google.com/drive/u/0/folders/1RM4jKy_3euv6cVq0BXcUe-KHxnWs4d1S) in adding the year. 

## Testing Instructions

 * Select a geography and year in the Netlify preview, then select at least three questions: an 'out of 10' question (waffle chart), an 'agree / disagree' question (stacked bar chart), and a question with a bolded answer below it (grouped bar chart).
 * Download the PNG for each chart. 
     - [x] The waffle chart should have the year displayed near the beginning of the question. 
     - [x] The bar charts should have the year displayed beside each bar.
 * Download a CSV for each chart. 
     - [x] There should be a 'year' column with the year entered for each row. 
 * Download all the charts using the 'download CSV' button near the top of the page. 
     - [x] There should be a 'year' column with the year entered for each row. 
