### PR TITLE
Fix horizontal chart scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update get-pip url [#109](https://github.com/azavea/fb-gender-survey-dashboard/pull/109)
+- Fix horizontal chart scrolling [#128](https://github.com/azavea/fb-gender-survey-dashboard/pull/128)
 
 ### Removed
 

--- a/src/app/src/components/DownloadMenu.jsx
+++ b/src/app/src/components/DownloadMenu.jsx
@@ -7,6 +7,7 @@ import {
     MenuButton,
     MenuList,
     MenuItem,
+    Portal,
 } from '@chakra-ui/react';
 import { FaDownload } from 'react-icons/fa';
 import { combineCanvases, setBackgroundColor, addTitle } from '../utils/canvas';
@@ -81,10 +82,12 @@ const DownloadMenu = ({
                     isRound={true}
                     icon={<FaDownload />}
                 />
-                <MenuList>
-                    <MenuItem onClick={saveImage}>PNG</MenuItem>
-                    <MenuItem onClick={saveCSV}>CSV</MenuItem>
-                </MenuList>
+                <Portal>
+                    <MenuList>
+                        <MenuItem onClick={saveImage}>PNG</MenuItem>
+                        <MenuItem onClick={saveCSV}>CSV</MenuItem>
+                    </MenuList>
+                </Portal>
             </Menu>
         </Flex>
     );


### PR DESCRIPTION
## Overview

After upgrading ChakraUI, the menu for the download menu was rendered
but hidden prior to being opened. This caused a gap the width of the
menu to appear to the right of the charts, resulting in charts scrolling
horizontally even on full-screen (charts are expected to scroll on
mobile only).

Rendering the menu list in a portal prevents the menu from effecting
the page layout, fixing the horizontal scroll.

Connects #127 

### Demo

Horizontal Scroll:
<img width="1237" alt="Screen Shot 2021-11-15 at 10 09 05 AM" src="https://user-images.githubusercontent.com/21046714/141805387-a86f8897-088f-4d23-8596-1613dce8e11a.png">

No Scroll:
<img width="1258" alt="Screen Shot 2021-11-15 at 10 08 16 AM" src="https://user-images.githubusercontent.com/21046714/141805377-051971d4-d59a-4ef9-beb1-128951ac5f95.png">

## Testing Instructions

 * On [staging](https://develop--gender-survey-dashboard.netlify.app), select some geographies and a question of each type (agree/disagree, out of ten, other), then attempt to scroll right on a chart. You will see the chart scroll and a gap appear at the right. Open the download menu and the gap will vanish. 
 * In the Netlify preview for this branch, select some geographies and a question of each type (agree/disagree, out of ten, other), then attempt to scroll right on a chart. The chart should not scroll. 
 * Open and use the download menu for each chart type to confirm it works as expected. 
 * Use mobile view and confirm the charts still scroll. We do not fully support mobile, but users should be able to access the site and view the charts with scrolling. 
