### PR TITLE
Update layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add year selector [#116](https://github.com/azavea/fb-gender-survey-dashboard/pull/116)
 - Add year in charts and downloads [#124](https://github.com/azavea/fb-gender-survey-dashboard/pull/124)
 - Update text [#129](https://github.com/azavea/fb-gender-survey-dashboard/pull/129)
+- Update layout [#130](https://github.com/azavea/fb-gender-survey-dashboard/pull/130)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Facebook Gender Survey Dashboard
+# Gender Survey Dashboard from Meta
 
-Interactive exploration of global results from the Facebook "Survey on Gender Equality At Home".
+Interactive exploration of global results from the Meta "Survey on Gender Equality At Home".
 
 Important links:
 
@@ -35,8 +35,7 @@ vagrant ssh
 
 ## Data
 
-The data used by this application is generated from a source set provided by
-Facebook's data team:
+The data used by this application is generated from a source set provided by Data for Good at Meta:
 
 <https://data.humdata.org/dataset/survey-on-gender-equality-at-home>
 

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -67,7 +67,7 @@
         <meta name="description" content="" />
         <meta
             name="Copyright"
-            content="Copyright © 2021 Facebook. All Rights Reserved."
+            content="Copyright © 2021 Meta, Inc. All Rights Reserved."
         />
 
         <!-- Open Graph / Facebook -->

--- a/src/app/src/components/AboutModal.jsx
+++ b/src/app/src/components/AboutModal.jsx
@@ -81,14 +81,14 @@ const AboutModal = ({ isOpen, onClose }) => {
                                     href='https://about.fb.com/news/2020/03/closing-the-gender-data-gap/'
                                     title='Project 17'
                                 />
-                                , two Facebook programs that use data to drive
+                                , two Meta programs that use data to drive
                                 progress on critical humanitarian issues. Data
                                 for Good provides tools built from
                                 privacy-protected data on Facebook’s platform,
                                 as well as tools developed using satellite
                                 imagery and other publicly available sources.
                                 Similarly, Project 17 emerged from a commitment
-                                Facebook made at the 2019 UN General Assembly to
+                                Meta made at the 2019 UN General Assembly to
                                 help partners use data to accelerate progress on
                                 the SDGs.
                             </StyledText>
@@ -121,7 +121,7 @@ const AboutModal = ({ isOpen, onClose }) => {
                                     href='https://facebookatunga.com/'
                                     title='here'
                                 />{' '}
-                                about how Facebook contributes to the SDGs.
+                                about how Meta contributes to the SDGs.
                             </StyledText>
                         </StyledAccordionItem>
                         <StyledAccordionItem title='Designing the survey'>

--- a/src/app/src/components/FaqModal.jsx
+++ b/src/app/src/components/FaqModal.jsx
@@ -135,11 +135,7 @@ const FaqModal = ({ isOpen, onClose }) => {
                                 representative of the online population of the
                                 country/region, but not the total (online and
                                 offline) population. Please be mindful of this
-                                limitation when conducting your analysis. We
-                                have included an estimate of Internet
-                                penetration for each country/region to give
-                                users a sense of the population that responses
-                                from each country represents.
+                                limitation when conducting your analysis.
                             </StyledText>
                         </StyledAccordionItem>
                         <StyledAccordionItem title='Where can I learn more about the specific limitations and features of each wave?'>

--- a/src/app/src/components/GeographySelector.jsx
+++ b/src/app/src/components/GeographySelector.jsx
@@ -8,11 +8,9 @@ import {
     Checkbox,
     CheckboxGroup,
     Text,
-    Image,
     Heading,
-    useMediaQuery,
-    VStack,
     Spacer,
+    SimpleGrid,
 } from '@chakra-ui/react';
 import { IoIosArrowRoundForward } from 'react-icons/io';
 import { IconContext } from 'react-icons';
@@ -25,8 +23,6 @@ import {
 import { CONFIG, GEO_COUNTRY, GEO_REGION, ROUTES } from '../utils/constants';
 import { formatQuery } from '../utils';
 import SearchInput from './SearchInput';
-import surveyMapImage from '../images/gender-survey-countries.png';
-import fallbackImage from '../images/fallback.jpg';
 
 const GeographySelector = () => {
     const history = useHistory();
@@ -101,10 +97,12 @@ const GeographySelector = () => {
         );
     }
 
-    // Show or hide the image based on a media query
-    const [isSmallScreen] = useMediaQuery('(max-width: 700px)');
+    const regionInputStyle = {
+        pointerEvents: 'none',
+        opacity: 0,
+    };
 
-    const section = (
+    return (
         <Box>
             <Flex layerStyle='selector'>
                 <Flex>
@@ -129,69 +127,70 @@ const GeographySelector = () => {
                 </Flex>
             </Flex>
             <Flex
-                m={{ base: 4, md: 8 }}
-                flexDirection={{
-                    base: 'column-reverse',
-                    md: 'column-reverse',
-                    lg: 'row',
-                }}
+                my={4}
+                mx={{ base: 4, md: 8, xl: 'auto' }}
+                mb='40px'
                 maxW='1200px'
-                mx={{ base: 4, lg: 'auto' }}
+                align='center'
+                justify='space-between'
+                flexWrap='wrap'
+            >
+                <Flex alignItems='baseline'>
+                    <Button
+                        className={geoMode === GEO_COUNTRY && 'current'}
+                        variant='link'
+                        size='lg'
+                        onClick={() => handleGeoSet(GEO_COUNTRY)}
+                    >
+                        Countries
+                    </Button>
+                    <Text
+                        fontSize='sm'
+                        textTransform='uppercase'
+                        mx='2'
+                        color='gray.600'
+                        fontWeight='medium'
+                    >
+                        or
+                    </Text>
+                    <Button
+                        className={geoMode === GEO_REGION && 'current'}
+                        variant='link'
+                        size='lg'
+                        onClick={() => handleGeoSet(GEO_REGION)}
+                    >
+                        Regions
+                    </Button>
+                </Flex>
+                <Box
+                    width={{ base: '100%', md: '350px' }}
+                    style={geoMode === GEO_REGION ? regionInputStyle : {}}
+                >
+                    <SearchInput
+                        query={query}
+                        setQuery={setQuery}
+                        placeholder='Search countries'
+                    />
+                </Box>
+            </Flex>
+            <Flex
+                m={{ base: 4, md: 8, xl: 'auto' }}
+                flexDirection='row'
+                maxW='1200px'
                 alignItems='flex-start'
                 justifyContent='space-between'
             >
-                <Flex
-                    flex='auto'
-                    direction='column'
-                    ml={{ base: 4, md: 8, xl: 0 }}
-                >
-                    <Box mb={4}>
-                        <Flex alignItems='baseline' mb={4}>
-                            <Button
-                                className={geoMode === GEO_COUNTRY && 'current'}
-                                variant='link'
-                                size='lg'
-                                onClick={() => handleGeoSet(GEO_COUNTRY)}
-                            >
-                                Countries
-                            </Button>
-                            <Text
-                                fontSize='sm'
-                                textTransform='uppercase'
-                                mx='2'
-                                color='gray.600'
-                                fontWeight='medium'
-                            >
-                                or
-                            </Text>
-                            <Button
-                                className={geoMode === GEO_REGION && 'current'}
-                                variant='link'
-                                size='lg'
-                                onClick={() => handleGeoSet(GEO_REGION)}
-                            >
-                                Regions
-                            </Button>
-                        </Flex>
-                        {geoMode === GEO_COUNTRY && (
-                            <Box maxW={{ md: '325px' }}>
-                                <SearchInput
-                                    query={query}
-                                    setQuery={setQuery}
-                                />
-                            </Box>
-                        )}
-                    </Box>
+                <Flex flex='auto' direction='column' justify='center'>
                     <Box id={`${geoMode}-selector-container`}>
                         <CheckboxGroup
                             key={`geogroup-${geoMode}`}
                             onChange={handleSelection}
                             defaultValue={currentGeo}
                         >
-                            <VStack
+                            <SimpleGrid
                                 spacing={5}
-                                direction='column'
-                                align='start'
+                                mb='50px'
+                                minChildWidth='250px'
                             >
                                 {geoList.length ? (
                                     geoList.map(geo => {
@@ -217,48 +216,13 @@ const GeographySelector = () => {
                                 ) : (
                                     <Text>No areas found.</Text>
                                 )}
-                            </VStack>
+                            </SimpleGrid>
                         </CheckboxGroup>
                     </Box>
                 </Flex>
-                {!isSmallScreen && (
-                    <Box
-                        maxWidth='750px'
-                        flex='auto'
-                        ml={{ base: 0, md: 8, lg: 8 }}
-                        mr={{ base: 4, md: 8, xl: 0 }}
-                        mb={{ base: 0, md: 8, lg: 0 }}
-                        boxShadow={{ base: 'none', md: 'none', lg: 'lg' }}
-                        borderRadius='lg'
-                        overflow='hidden'
-                        position='relative'
-                    >
-                        <Box
-                            bg='red.700'
-                            position='absolute'
-                            bottom='0'
-                            right='0'
-                            zIndex='docked'
-                            px={3}
-                            py={2}
-                        >
-                            <Text color='white' fontSize='xs' fontWeight={500}>
-                                Red indicates countries included in the survey.
-                            </Text>
-                        </Box>
-                        <Image
-                            src={surveyMapImage}
-                            fallbackSrc={fallbackImage}
-                            htmlHeight={1082}
-                            htmlWidth={1500}
-                            alt='Countries and regions surveyed in the Survey on Gender Equality at Home.'
-                        />
-                    </Box>
-                )}
             </Flex>
         </Box>
     );
-    return section;
 };
 
 export default GeographySelector;

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -385,6 +385,10 @@ const QuestionSelector = () => {
                 my={2}
                 mx={{ base: 4, md: 4, lg: 8, xl: 'auto' }}
                 maxW='1200px'
+                align='center'
+                justify='space-between'
+                mb={4}
+                flexWrap='wrap'
             >
                 <Text size='2xl' fontWeight='bold'>
                     Showing questions for: {currentYears.join(', ')}
@@ -397,18 +401,15 @@ const QuestionSelector = () => {
                         availableYearsGeography,
                     })}
                 </Text>
+                <Box width={{ base: '100%', md: '350px' }}>
+                    <SearchInput
+                        query={query}
+                        setQuery={handleSetQuery}
+                        placeholder='Search questions and answers'
+                    />
+                </Box>
             </Flex>
-            <Flex
-                direction='column'
-                maxW='1200px'
-                my={{ lg: 8 }}
-                mx={{ base: 4, lg: 'auto' }}
-            >
-                <Flex mb={4} justify='flex-end'>
-                    <Box width={{ base: '100%', md: '350px' }}>
-                        <SearchInput query={query} setQuery={handleSetQuery} />
-                    </Box>
-                </Flex>
+            <Flex direction='column' maxW='1200px' mx={{ base: 4, lg: 'auto' }}>
                 <Box>
                     <CheckboxGroup
                         size='xl'

--- a/src/app/src/components/YearSelector.jsx
+++ b/src/app/src/components/YearSelector.jsx
@@ -80,7 +80,7 @@ const YearSelector = () => {
             <Flex layerStyle='selector'>
                 <Flex>
                     <Heading as='h2' textStyle='h2' mb='0'>
-                        Select the year(s) to view
+                        Select the survey year
                     </Heading>
                     <Spacer />
                     <Button
@@ -110,15 +110,9 @@ const YearSelector = () => {
             </Flex>
             <Flex
                 m={{ base: 4, md: 8 }}
-                flexDirection={{
-                    base: 'column-reverse',
-                    md: 'column-reverse',
-                    lg: 'row',
-                }}
+                flexDirection='column-reverse'
                 maxW='1200px'
                 mx={{ base: 4, lg: 'auto' }}
-                alignItems='flex-start'
-                justifyContent='space-between'
             >
                 <Flex
                     flex='auto'


### PR DESCRIPTION
## Overview

We removed the map on the main page to address boundary / border
concerns. In order to better maintain a appealing homepage, we then
adjusted the layout on the homepage to use multiple columns for the
countries and regions.

We also applied some minor adjustments to the layout throughout the
site for consistency and accessibility, adjusting text for clarity,
adding placeholder text to inputs, and moving the search inputs to be
inline with page text.

Connects #126 

### Demo

<img width="1402" alt="Screen Shot 2021-11-16 at 12 00 11 PM" src="https://user-images.githubusercontent.com/21046714/142031177-32127109-09b1-4ee0-bb59-f9049b136943.png">
<img width="1395" alt="Screen Shot 2021-11-16 at 12 00 23 PM" src="https://user-images.githubusercontent.com/21046714/142031199-4daed17f-f4af-4180-b612-b16f5cdd52a1.png">
<img width="1396" alt="Screen Shot 2021-11-16 at 12 00 45 PM" src="https://user-images.githubusercontent.com/21046714/142031213-26b06baf-c09d-4652-837a-1dff8c1389f8.png">


## Testing Instructions

 * In the Netlify preview, view the countries on the homepage, and adjust the page width to confirm the columns respond reasonably at various screen sizes.  
 * Toggle to regions, and confirm that the search input disappears but the height of the region/country toggle remains the same. 
 * View the years page. The text should read 'survey year' instead of 'year(s)'. 
 * View the questions page. The search input should appear inline with the text at the top of the page. 
 * Confirm that the changes listed under ['How the survey contributes'](https://docs.google.com/document/d/178h9_bdBg2k5jiT1O8W50LAQJzMAvD1ydCv-z6nKBfw/edit#heading=h.cxvyw1914iu1) are present in the about modal. 
 * "Copyright © 2021 Facebook. All Rights Reserved." should be "Meta, Inc." instead of Facebook in the meta tags.
 * Confirm requested changes to the readme text:
     - "Facebook Gender Survey Dashboard" changed to "Gender Survey Dashboard from Meta"
     - "Interactive exploration of global results from the Facebook "Survey on Gender Equality At Home"" (changed Facebook to Meta) 
     - "The data used by this application is generated from a source set provided by Facebook's data team:" changed to "...provided by Data for Good at Meta."
