### PR TITLE
Allow users to select multiple years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow users to select multiple years [#138](https://github.com/azavea/fb-gender-survey-dashboard/pull/138)
+
 ### Changed
 
 ### Fixed

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -200,7 +200,9 @@ const QuestionSelector = () => {
     };
 
     Object.entries(config.survey)
-        .filter(([key, question]) => !dataIndexer.isDataUnavailable(key))
+        .filter(([key, question]) =>
+            currentYears.some(year => !dataIndexer.isDataUnavailable(key, year))
+        )
         .forEach(([key, question]) => {
             const categoryCode = question.qcode[0].toUpperCase();
 

--- a/src/app/src/components/StackedBarChart.js
+++ b/src/app/src/components/StackedBarChart.js
@@ -10,32 +10,43 @@ import { formatStackedCSV } from '../utils/csv';
 const StackedBarChart = ({ items }) => {
     const { currentYears } = useSelector(state => state.app);
     const containerRefs = useRefs(items.length);
+
     return items.map(({ question, responses }, i) => {
         const data = currentYears
-            .map(year =>
-                responses
+            .map(year => {
+                const validResponses = responses
                     .filter(r => r.year === year)
-                    .reduce(
-                        (acc, curr) => {
-                            acc[0][curr.cat] = Math.round(curr.combined, 2);
-                            acc[1][curr.cat] = Math.round(curr.male, 2);
-                            acc[2][curr.cat] = Math.round(curr.female, 2);
-                            return acc;
-                        },
-                        [
-                            { index: `Total ${year}` },
-                            { index: `Men ${year}` },
-                            { index: `Women ${year}` },
-                        ]
-                    )
-            )
+                    .filter(r => !r.dataUnavailable);
+                return validResponses.length
+                    ? validResponses.reduce(
+                          (acc, curr) => {
+                              acc[0][curr.cat] = Math.round(curr.combined, 2);
+                              acc[1][curr.cat] = Math.round(curr.male, 2);
+                              acc[2][curr.cat] = Math.round(curr.female, 2);
+                              return acc;
+                          },
+                          [
+                              { index: `Total ${year}` },
+                              { index: `Men ${year}` },
+                              { index: `Women ${year}` },
+                          ]
+                      )
+                    : validResponses;
+            })
             .flat();
-        const keys = responses.map(r => r.cat);
+
+        const keys = [
+            'Strongly Agree/Agree',
+            'Strongly Disagree/Disagree',
+            'Neutral',
+        ];
         const formatValue = v => `${v}%`;
+
+        const height = 100 + data.length * 35;
 
         return (
             <Box
-                h={200}
+                h={height}
                 className='chart-container'
                 key={`stacked-${question.question.qcode}-${responses[0].geo}`}
                 ref={containerRefs.current[i]}

--- a/src/app/src/components/Visualizations.jsx
+++ b/src/app/src/components/Visualizations.jsx
@@ -121,10 +121,12 @@ const Visualizations = () => {
         setSaved(true);
     };
 
-    const createKey = items =>
-        items[0].response
-            ? `${items[0].response.key}-${items[0].response.geo}`
-            : `${items[0].responses[0].key}-${items[0].responses[0].geo}`;
+    const createKey = items => {
+        const response = items[0].response
+            ? items[0].response
+            : items[0].responses[0];
+        return `${response.key}-${response.geo}-${response.year}`;
+    };
 
     return (
         <Box>

--- a/src/app/src/components/WaffleChart.js
+++ b/src/app/src/components/WaffleChart.js
@@ -33,8 +33,11 @@ const WaffleChart = ({ items }) => {
                 },
             ],
         ];
+
+        const key = `waffle-${question.qcode}-${response.geo}-${response.year}`;
+
         return (
-            <Box py={4} key={`waffle-${question.qcode}${response.geo}`}>
+            <Box py={4} key={key}>
                 <Flex justify='center' mb={2}>
                     <Text as='strong' size='sm'>
                         {response.geo} {response.year}
@@ -48,7 +51,7 @@ const WaffleChart = ({ items }) => {
                     borderColor='gray.100'
                     borderRadius='md'
                     className='chart-container'
-                    key={`waffle-${question.qcode}${response.geo}`}
+                    key={key}
                     ref={containerRefs.current[i]}
                 >
                     <DownloadMenu
@@ -67,7 +70,7 @@ const WaffleChart = ({ items }) => {
                         {responses.map(data => (
                             <ResponsiveWaffleCanvas
                                 data={data}
-                                key={`waffle-${question.qcode}${response.geo}${data[0].label}`}
+                                key={`${key}-${data[0].label}`}
                                 pixelRatio={2}
                                 colors={item => {
                                     if (item.label === 'Women') {

--- a/src/app/src/components/YearSelector.jsx
+++ b/src/app/src/components/YearSelector.jsx
@@ -5,8 +5,8 @@ import {
     Box,
     Flex,
     Button,
-    Radio,
-    RadioGroup,
+    Checkbox,
+    CheckboxGroup,
     useMediaQuery,
     Text,
     Heading,
@@ -63,7 +63,7 @@ const YearSelector = () => {
     }
 
     const handleSelection = selections => {
-        dispatch(setYears([selections]));
+        dispatch(setYears(selections));
     };
 
     const handleNext = () => {
@@ -120,10 +120,10 @@ const YearSelector = () => {
                     ml={{ base: 4, md: 8, xl: 0 }}
                 >
                     <Box id={`year-selector-container`}>
-                        <RadioGroup
+                        <CheckboxGroup
                             key={`year-selector`}
                             onChange={handleSelection}
-                            value={currentYears[0]}
+                            value={currentYears}
                         >
                             <VStack
                                 spacing={5}
@@ -138,7 +138,7 @@ const YearSelector = () => {
                                             g => !geos.includes(g)
                                         );
                                         return (
-                                            <Radio
+                                            <Checkbox
                                                 key={`year-${year}`}
                                                 value={year}
                                                 size='lg'
@@ -151,14 +151,14 @@ const YearSelector = () => {
                                                           ', '
                                                       )})`
                                                     : ''}
-                                            </Radio>
+                                            </Checkbox>
                                         );
                                     })
                                 ) : (
                                     <Text>No years available.</Text>
                                 )}
                             </VStack>
-                        </RadioGroup>
+                        </CheckboxGroup>
                     </Box>
                 </Flex>
             </Flex>


### PR DESCRIPTION
## Overview

Users can select multiple years on the years selection page, and
questions are formatted appropriately for multiple years.

Questions/options are hidden on the question selection page only if
they are unavailable for all selected years for all selected
geographies.

Displays comparative view for StackedBarChart and GroupedBarChart by adding a row for each answer type
for each year.

Connects #133, #135, #136 

### Demo

<img width="432" alt="Screen Shot 2021-11-29 at 11 15 13 AM" src="https://user-images.githubusercontent.com/21046714/144079157-2342f75e-e883-45b2-abb0-e9840ea6f73c.png">
<img width="1248" alt="Screen Shot 2021-11-29 at 11 15 37 AM" src="https://user-images.githubusercontent.com/21046714/144079210-bb7b1c3c-daa1-4b1c-9031-9166d1ca8c74.png">
<img width="1188" alt="Screen Shot 2021-11-29 at 11 13 35 AM" src="https://user-images.githubusercontent.com/21046714/144079098-4464ab55-85fc-440d-bf06-6894b586adb7.png">
<img width="1188" alt="Screen Shot 2021-11-29 at 11 13 15 AM" src="https://user-images.githubusercontent.com/21046714/144079129-488af007-b10c-416a-b2cc-8c15be6baec4.png">

## Notes

Comparative view design for WaffleCharts hasn't been finalized, so for the moment, each year / country will load as a separate set of waffle charts. Comparative view for WaffleChart question will be built in #137.

## Testing Instructions

 * In the Netlify preview, select a country with only 2020 data. Only 2020 should be available on the years page.
 * Select a country with only 2021 data. Only 2021 should be available on the years page.
 * Select countries with both years available, a country with only 2020 data, and a country with only 2021 data. 
 * Select 2020 on the years page. On the questions page, the number of options available should match the number of options available on production for 2020.
* Select 2021 on the years page. On the questions page, the number of options available should match the number of options available on production for 2021.
* Select 2020 and 2021 on the years page. On the questions page, all options should be available. 
* Select the following options, then view the charts page:
     - How many other people live with you under the same roof? Please do not count yourself (0, I live alone)
     - Out of 10 of your neighbors, how many do you think believe that girls and boys should share household tasks equally? 
     -  Do you agree or disagree with the statement? "There are times when I feel uncomfortable or even unsafe in my house."
* The StackedBarChart and the GroupedBarChart should display both 2020 and 2021 data. The countries with only one year of data available should be included in the charts for the year that are available. 
* On the questions page, select all options, then go to the charts page (it might take a moment to load). 
* All charts / questions should render without breaking.