### PR TITLE
Update meta tags and handle null geoMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update meta tags and handle null geoMode [#140](https://github.com/azavea/fb-gender-survey-dashboard/pull/140)
+
 ### Fixed
 
 ### Removed

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -76,7 +76,7 @@
         <meta property="og:title" content="Gender Equality at Home" />
         <meta
             property="og:description"
-            content="Visualize aggregate data from over the 2020 Survey on Gender Equality at Home, which reached over 460,000 Facebook users in 208 locations around the world."
+            content="Explore the country and region-level data from the 2020 and 2021 waves of the Survey on Gender Equality at Home."
         />
         <meta property="og:image" content="%PUBLIC_URL%/meta_image.jpg" />
 
@@ -86,7 +86,7 @@
         <meta property="twitter:title" content="Gender Equality at Home" />
         <meta
             property="twitter:description"
-            content="Visualize aggregate data from over the 2020 Survey on Gender Equality at Home, which reached over 460,000 Facebook users in 208 locations around the world."
+            content="Explore the country and region-level data from the 2020 and 2021 waves of the Survey on Gender Equality at Home."
         />
         <meta property="twitter:image" content="%PUBLIC_URL%/meta_image.jpg" />
     </head>

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { ChakraProvider } from '@chakra-ui/react';
 import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import 'focus-visible/dist/focus-visible';
@@ -15,11 +15,13 @@ import SurveyNotification from './components/SurveyNotification';
 import NotFound from './components/NotFound';
 import theme from './theme';
 
-import { setData } from './redux/app.actions';
+import { setData, setGeoSelectionMode } from './redux/app.actions';
 import { GEO_COUNTRY, GEO_REGION, ROUTES } from './utils/constants';
+import { isValidGeoMode } from './utils';
 
 function App() {
     const dispatch = useDispatch();
+    const geoMode = useSelector(state => state.app.geoMode);
 
     useEffect(() => {
         // Fetch data at application start
@@ -35,6 +37,16 @@ function App() {
                 dispatch(setData({ [GEO_REGION]: data }));
             });
     }, [dispatch]);
+
+    useEffect(() => {
+        if (!isValidGeoMode(geoMode)) {
+            dispatch(setGeoSelectionMode(GEO_COUNTRY));
+        }
+    }, [geoMode, dispatch]);
+
+    if (!isValidGeoMode(geoMode)) {
+        return null;
+    }
 
     return (
         <Router>

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { CONFIG } from './constants';
+import { CONFIG, GEO_REGION, GEO_COUNTRY } from './constants';
 
 export const set = field =>
     produce((state, payload) => {
@@ -177,3 +177,6 @@ export const formatCurrentGeo = ({
             )
         )
         .join(', ');
+
+export const isValidGeoMode = geoMode =>
+    geoMode === GEO_REGION || geoMode === GEO_COUNTRY;


### PR DESCRIPTION
## Overview

Updates the meta tags to use new text for 2021 (swapping out "Visualize aggregate data from over the 2020 Survey on Gender Equality at Home, which reached over 460,000 Facebook users in 208 locations around the world" with "Explore the country and region-level data from the 2020 and 2021 waves of the Survey on Gender Equality at Home.") per client request. 

Adds protections to handle a null or invalid geoMode. The geography mode (region or country) must be selected for the app to successfully access the data and work as expected. This value is set to countries by default, but in the case of an invalid value somehow entering the system, the app will reset the value to countries, and prevent content from loading until a valid value is found.

Connects #131, #139

### Notes

A separate commit with an invalid geoMode set by default has been pushed. Drop this before merging. 

## Testing Instructions

 * Copy the URL for the Netlify preview and send it to yourself in Slack. You should see the new meta text.
 * View the app in the Netlify preview and confirm that countries is selected automatically and the app does not crash. 
