### PR TITLE
Format comparative bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow users to select multiple years [#138](https://github.com/azavea/fb-gender-survey-dashboard/pull/138)
+- Format comparative bar charts [#142](https://github.com/azavea/fb-gender-survey-dashboard/pull/142)
 
 ### Changed
 


### PR DESCRIPTION
## Overview

Orders the years listed in the charts from least- to most-recent
and adds a gap in between the years to keep the data distinct.

Connects #141 

### Demo

<img width="1224" alt="Screen Shot 2021-12-30 at 3 27 09 PM" src="https://user-images.githubusercontent.com/21046714/147786136-7c0919b5-d855-40c4-a711-8ff133f3c8ef.png">
<img width="1215" alt="Screen Shot 2021-12-30 at 3 27 52 PM" src="https://user-images.githubusercontent.com/21046714/147786140-cea05ab4-403e-4ad5-81cc-e9d2432004b2.png">

## Testing Instructions

 * In the Netlify preview, select two locations which are available in multiple years and select multiple years. 
 * Select a multi-year StackedBarChart question and a GroupedBarChart question (such as "How many other people live with you under the same roof? Please do not count yourself" and "Do you agree or disagree with the statement? "There are times when I feel uncomfortable or even unsafe in my house.""). 
 * View the charts and confirm they are styled with a gap in between the years and the years are ordered. 
