### PR TITLE
View 'out of ten' charts in comparative view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow users to select multiple years [#138](https://github.com/azavea/fb-gender-survey-dashboard/pull/138)
 - Format comparative bar charts [#142](https://github.com/azavea/fb-gender-survey-dashboard/pull/142)
+- View 'out of ten' charts in comparative view [#143](https://github.com/azavea/fb-gender-survey-dashboard/pull/143)
 
 ### Changed
 

--- a/src/app/src/components/Chart.js
+++ b/src/app/src/components/Chart.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Box, Text } from '@chakra-ui/react';
 
 import StackedBarChart from './StackedBarChart';
@@ -6,6 +7,7 @@ import WaffleChart from './WaffleChart';
 import GroupedBarChart from './GroupedBarChart';
 
 const Chart = ({ items }) => {
+    const { currentYears } = useSelector(state => state.app);
     const { question } = items[0];
 
     const data = items.filter(
@@ -43,7 +45,7 @@ const Chart = ({ items }) => {
     let chart;
     if (question.type === 'stack') {
         chart = <StackedBarChart items={data} />;
-    } else if (question.type === 'ten') {
+    } else if (question.type === 'ten' && currentYears.length < 2) {
         chart = <WaffleChart items={data} />;
     } else {
         chart = <GroupedBarChart items={data} />;

--- a/src/app/src/components/GroupedBarChart.js
+++ b/src/app/src/components/GroupedBarChart.js
@@ -32,6 +32,14 @@ const formatResponsesForChart = ({ items, sortedYears }) => {
     ).flat();
 };
 
+const getMaxValue = type => {
+    if (type === 'pct') return 100;
+
+    if (type === 'ten') return 10;
+
+    return 'auto';
+};
+
 const GroupedBarChart = ({ items }) => {
     const { currentYears } = useSelector(state => state.app);
     const sortedYears = sortBy(currentYears, year => parseInt(year)).reverse();
@@ -77,6 +85,7 @@ const GroupedBarChart = ({ items }) => {
     const containerRef = useRef();
 
     const height = 150 + data.length * 50;
+    const maxValue = getMaxValue(type);
 
     return (
         <Box
@@ -112,7 +121,7 @@ const GroupedBarChart = ({ items }) => {
                 enableGridX={true}
                 enableGridY={false}
                 minValue='auto'
-                maxValue={isPercent ? 100 : 'auto'}
+                maxValue={maxValue}
                 groupMode='grouped'
                 layout='horizontal'
                 colors={item => {


### PR DESCRIPTION
## Overview

Some questions contain the phrase 'out of ten of your neighbors...'
These questions are formatted as WaffleCharts when viewed as a
single-year chart. However, because each piece of data must be
rendered as a separate waffle chart, this isn't conducive for
comparative view. When viewed with multiple years selected, these
questions are instead displayed as a GroupedBarChart with the maximum
value set to 10.

Connects #137 

### Demo

<img width="1187" alt="Screen Shot 2022-01-05 at 11 41 55 AM" src="https://user-images.githubusercontent.com/21046714/148255241-a1d5ab03-bf29-41e8-9648-7ae19c9caaa5.png">

## Testing Instructions

 * Select geographies that cover multiple years, select multiple years, and select all of the available 'out of 10' questions. Select several grouped bar chart questions that are not 'out of 10' as well.
 * The charts should be bar charts. The maximum value for the 'out of 10' charts should be 10. The other bar charts should work as before. 
 * Select the same geographies, a single year, and the 'out of 10' questions. 
 * The charts should be waffle charts. 