### PR TITLE
Allow comparative chart download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow users to select multiple years [#138](https://github.com/azavea/fb-gender-survey-dashboard/pull/138)
 - Format comparative bar charts [#142](https://github.com/azavea/fb-gender-survey-dashboard/pull/142)
 - View 'out of ten' charts in comparative view [#143](https://github.com/azavea/fb-gender-survey-dashboard/pull/143)
+- Allow comparative chart download [#144](https://github.com/azavea/fb-gender-survey-dashboard/pull/144)
 
 ### Changed
 

--- a/src/app/src/components/DownloadMenu.jsx
+++ b/src/app/src/components/DownloadMenu.jsx
@@ -54,7 +54,7 @@ const DownloadMenu = ({
                 : chartCanvases[0];
 
         const title = `Question ${question.qcode}${
-            question.type === 'ten'
+            question.type === 'ten' && currentYears.length < 2
                 ? ` in ${question.geo} in ${question.year}`
                 : ''
         }: ${question.question}`;

--- a/src/app/src/utils/csv.js
+++ b/src/app/src/utils/csv.js
@@ -19,10 +19,11 @@ const addCSVResponse = ({ question, response, data }) => {
         response.cat,
         response.key,
     ];
-
-    data.push([...row, 'male', response.male]);
-    data.push([...row, 'female', response.female]);
-    data.push([...row, 'combined', response.combined]);
+    if (response.male || response.female || response.combined) {
+        data.push([...row, 'male', response.male]);
+        data.push([...row, 'female', response.female]);
+        data.push([...row, 'combined', response.combined]);
+    }
 };
 
 export const formatWaffleCSV = (item, data = []) => {


### PR DESCRIPTION
## Overview

Updates the comparative chart download to correctly format the comparative "out of ten" chart titles. 

Connects #118 

### Demo

![2020_2021_A 2_Out of 10 of your neighbors, how many do you think believe that girls and boys should share household tasks equally_ Please enter a whole number between 0 and 10 (1)](https://user-images.githubusercontent.com/21046714/148605435-bfc46314-7041-4bd6-8782-ba378af37981.png)

## Testing Instructions

 * Select a combination of geographies for multiple years and geographies for one year, then select multiple years and a question of each type (stacked bar chart, grouped bar chart, and waffle / out-of-ten chart). 
 * Download the image for each chart.
 * Download the CSV for each chart.
 * Download the CSV for the full page.
 * Repeat the above steps with only one year selected. 
 * The images and CSVs should download correctly and without errors. 
