### PR TITLE
Add build tools in dataproc container

### DIFF
--- a/src/dataproc/Dockerfile
+++ b/src/dataproc/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.9-slim
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --default-timeout=100 -r /tmp/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential python3-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --default-timeout=100 -r /tmp/requirements.txt \
+    && apt-get purge -y --auto-remove build-essential python3-dev
 
 WORKDIR /opt/src
 


### PR DESCRIPTION
## Overview

When pre-built wheels are not available for certain architectures, like the new M1 Apple Silicons, they need to be built locally in the container. The Python Slim container does not come with build tools by default.

This adds the build tools before installing dependencies, then removes them so the image stays slim.

## Testing Instructions

* Run `update`
  - [x] Ensure it works as expected