### PR TITLE
Show available years for options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Format comparative bar charts [#142](https://github.com/azavea/fb-gender-survey-dashboard/pull/142)
 - View 'out of ten' charts in comparative view [#143](https://github.com/azavea/fb-gender-survey-dashboard/pull/143)
 - Allow comparative chart download [#144](https://github.com/azavea/fb-gender-survey-dashboard/pull/144)
+- Show available years for options [#150](https://github.com/azavea/fb-gender-survey-dashboard/pull/150)
 
 ### Changed
 

--- a/src/app/src/components/QuestionSelector.jsx
+++ b/src/app/src/components/QuestionSelector.jsx
@@ -7,6 +7,7 @@ import {
     AccordionIcon,
     AccordionPanel,
     AccordionButton,
+    Badge,
     Box,
     Button,
     Checkbox,
@@ -223,6 +224,19 @@ const QuestionSelector = () => {
         });
 
     const getQuestionCheckboxLabel = key => {
+        const availableYears = currentYears.filter(
+            year => !dataIndexer.isDataUnavailable(key, year)
+        );
+        const isMultiYear = currentYears.length > 1;
+        const availableYearsNote =
+            isMultiYear && availableYears.length
+                ? availableYears.map(year => (
+                      <Badge colorScheme='red' ml={1}>
+                          {year}
+                      </Badge>
+                  ))
+                : '';
+
         // Generate a checkbox for a question. The checkbox text will differ
         // depending on the type of question this is. Questions that are of type
         // "stack" will not include response text in the text, nor will the
@@ -235,7 +249,9 @@ const QuestionSelector = () => {
             if (item.cat) {
                 return (
                     <Box fontWeight='400'>
-                        <Text fontSize='inherit'>{item.question}</Text>
+                        <Text fontSize='inherit'>
+                            {item.question} {availableYearsNote}
+                        </Text>
                         <Text
                             fontSize='inherit'
                             fontWeight='bold'
@@ -246,7 +262,9 @@ const QuestionSelector = () => {
 
             return (
                 <Box fontWeight='regular'>
-                    <Text fontSize='inherit'>{item.question}</Text>
+                    <Text fontSize='inherit'>
+                        {item.question} {availableYearsNote}
+                    </Text>
                 </Box>
             );
         }
@@ -255,7 +273,11 @@ const QuestionSelector = () => {
         // the question from any of the respones/question paris that share the
         // qcode.
         const item = Object.values(config.survey).find(q => q.qcode === key);
-        return item.question;
+        return (
+            <span>
+                {item.question} {availableYearsNote}
+            </span>
+        );
     };
 
     const categories = getCategoryData(query).map(

--- a/src/app/src/utils/index.js
+++ b/src/app/src/utils/index.js
@@ -74,7 +74,13 @@ export class DataIndexer {
     }
 
     formatForViz(key, geo, year) {
-        const resp = this.survey[key];
+        let resp = this.survey[key];
+        if (key.includes('.')) {
+            // This is a Likert scale question, which use a qcode as an
+            // identifier instead of a key. We can grab the question from one of
+            // the response/question pairs that share the qcode.
+            resp = Object.values(this.survey).find(q => q.qcode === key);
+        }
         if (!resp) {
             return { key, geo, dataUnavailable: true };
         }


### PR DESCRIPTION
## Overview

When multiple years are selected, displays a badge or badges
beside each option in the question selector to indicate for
which years that option is available, given currently selected
geographies.

Connects #148 

### Demo

<img width="1231" alt="Screen Shot 2022-01-21 at 9 25 57 AM" src="https://user-images.githubusercontent.com/21046714/150564591-45c86d05-f10c-46a2-876c-a1aadda2f8e0.png">

### Notes

The red color of the badges is by specific client request.

## Testing Instructions

 * Select multiple years and navigate to the questions selector
 * Options should indicate for which years they are available
